### PR TITLE
Surface worker errors and runCycle telemetry to AppSignal

### DIFF
--- a/packages/data-collector/public/py_worker.js
+++ b/packages/data-collector/public/py_worker.js
@@ -29,10 +29,43 @@ onmessage = (event) => {
   }
 };
 
+let cycleCount = 0;
+
 function runCycle(payload) {
+  const cycleId = ++cycleCount;
+  const payloadType = (payload && payload.__type__) || "null";
   console.log("[ProcessingWorker] runCycle " + JSON.stringify(payload));
+  self.postMessage({
+    eventType: "workerLog",
+    level: "debug",
+    message: `[Worker] runCycle #${cycleId} starting, payload=${payloadType}`,
+  });
+  let scriptEvent;
   try {
     scriptEvent = pyScript.send(payload);
+  } catch (error) {
+    console.error("[ProcessingWorker] Error in pyScript.send:", error);
+    self.postMessage({
+      eventType: "error",
+      error: error.toString(),
+      stack: error.stack || "",
+    });
+    return;
+  }
+  let commandType = "unknown";
+  try {
+    if (scriptEvent && typeof scriptEvent.get === "function") {
+      commandType = scriptEvent.get("__type__") || "unknown";
+    }
+  } catch (e) {
+    commandType = `unreadable (${e.message})`;
+  }
+  self.postMessage({
+    eventType: "workerLog",
+    level: "debug",
+    message: `[Worker] runCycle #${cycleId} got command=${commandType}`,
+  });
+  try {
     self.postMessage({
       eventType: "runCycleDone",
       scriptEvent: scriptEvent.toJs({
@@ -41,7 +74,7 @@ function runCycle(payload) {
       }),
     });
   } catch (error) {
-    console.error("[ProcessingWorker] Error in runCycle:", error);
+    console.error("[ProcessingWorker] Error in toJs/postMessage:", error);
     self.postMessage({
       eventType: "error",
       error: error.toString(),

--- a/packages/feldspar/src/framework/processing/worker_engine.ts
+++ b/packages/feldspar/src/framework/processing/worker_engine.ts
@@ -1,5 +1,5 @@
 import { CommandHandler } from '../types/modules'
-import { CommandSystemEvent, isCommand, Response } from '../types/commands'
+import { CommandSystemEvent, CommandSystemLog, isCommand, Response } from '../types/commands'
 
 export default class WorkerProcessingEngine  {
   sessionId: String
@@ -46,12 +46,44 @@ export default class WorkerProcessingEngine  {
         console.log('[ReactEngine] received: event', event.data.scriptEvent)
         this.handleRunCycle(event.data.scriptEvent)
         break
+
+      case 'error':
+        console.error(
+          '[ReactEngine] worker error:',
+          event.data.error,
+          event.data.stack
+        )
+        this.handleWorkerError(event.data.error, event.data.stack)
+        break
+
+      case 'workerLog':
+        this.forwardWorkerLog(event.data.level, event.data.message)
+        break
+
       default:
         console.log(
           '[ReactEngine] received unsupported flow event: ',
           eventType
         )
     }
+  }
+
+  handleWorkerError (error: string, stack: string): void {
+    const message = `[Worker] Error in runCycle: ${error}${stack ? `\n${stack}` : ''}`
+    this.forwardWorkerLog('error', message)
+  }
+
+  forwardWorkerLog (level: string, message: string): void {
+    const command: CommandSystemLog = {
+      __type__: 'CommandSystemLog',
+      level,
+      message,
+      json_string: JSON.stringify({ level, message })
+    }
+    this.commandHandler.onCommand(command).then(
+      () => {},
+      () => {}
+    )
   }
 
   start (): void {


### PR DESCRIPTION
## Summary

- Forwards `eventType: "error"` from the Pyodide worker as a `CommandSystemLog` so pyodide exceptions surface in AppSignal with a stack trace (previously silently dropped by `WorkerProcessingEngine.handleEvent`).
- Adds `[Worker] runCycle #N starting, payload=X` and `[Worker] runCycle #N got command=Y` around each `pyScript.send(...)` so a frozen session reveals which side of the call is hung.
- Splits the worker's try/catch so `pyScript.send` errors and `toJs`/`postMessage` errors are reported distinctly.

## Why

For participants using the Instagram data donation, the extraction deterministically freezes between step 2 (`extract_video_posts`) and step 3 (`extract_comments_and_likes`). The last visible log is `extract_data: Video posts extracted successfully`, after which AppSignal shows only health-check pings. No exception was observable because the worker's error handler posted `eventType: "error"` but the main thread ignored it.

Related: Basecamp issue 9789334488 (milestone 7.1 - Hotfix error monitoring).

## Test plan

- [x] `pnpm --filter @eyra/feldspar build` — passes
- [x] `pnpm --filter @eyra/data-collector build` — passes
- [x] Pre-commit Playwright e2e (`tests/donation.spec.ts`) — passes
- [ ] Deploy to production before the next participant session
- [ ] Confirm AppSignal receives `[Worker] runCycle #N starting/got command` lines during a normal donation
- [ ] Confirm AppSignal receives `[Worker] Error in runCycle: …` with a stack trace when the next Instagram session freezes

🤖 Generated with [Claude Code](https://claude.com/claude-code)