### PR TITLE
Merge milestone/1.1 into master (error monitoring hotfix)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,3 +77,4 @@ jobs:
           files: ${{ env.RELEASE_NAME }}
           prerelease: ${{ env.BRANCH != 'main' }}
           generate_release_notes: true
+          target_commitish: ${{ github.sha }}

--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ node_modules/
 
 tests/random_instagram_fixture/
 tests/random_instagram_fixture_legacy/
+tests/random_instagram_fixture*.zip

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ node_modules/
 .artifacts/
 
 
+tests/random_instagram_fixture/

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ node_modules/
 
 
 tests/random_instagram_fixture/
+tests/random_instagram_fixture_legacy/

--- a/packages/data-collector/public/py_worker.js
+++ b/packages/data-collector/public/py_worker.js
@@ -29,10 +29,43 @@ onmessage = (event) => {
   }
 };
 
+let cycleCount = 0;
+
 function runCycle(payload) {
+  const cycleId = ++cycleCount;
+  const payloadType = (payload && payload.__type__) || "null";
   console.log("[ProcessingWorker] runCycle " + JSON.stringify(payload));
+  self.postMessage({
+    eventType: "workerLog",
+    level: "debug",
+    message: `[Worker] runCycle #${cycleId} starting, payload=${payloadType}`,
+  });
+  let scriptEvent;
   try {
     scriptEvent = pyScript.send(payload);
+  } catch (error) {
+    console.error("[ProcessingWorker] Error in pyScript.send:", error);
+    self.postMessage({
+      eventType: "error",
+      error: error.toString(),
+      stack: error.stack || "",
+    });
+    return;
+  }
+  let commandType = "unknown";
+  try {
+    if (scriptEvent && typeof scriptEvent.get === "function") {
+      commandType = scriptEvent.get("__type__") || "unknown";
+    }
+  } catch (e) {
+    commandType = `unreadable (${e.message})`;
+  }
+  self.postMessage({
+    eventType: "workerLog",
+    level: "debug",
+    message: `[Worker] runCycle #${cycleId} got command=${commandType}`,
+  });
+  try {
     self.postMessage({
       eventType: "runCycleDone",
       scriptEvent: scriptEvent.toJs({
@@ -41,7 +74,7 @@ function runCycle(payload) {
       }),
     });
   } catch (error) {
-    console.error("[ProcessingWorker] Error in runCycle:", error);
+    console.error("[ProcessingWorker] Error in toJs/postMessage:", error);
     self.postMessage({
       eventType: "error",
       error: error.toString(),

--- a/packages/feldspar/src/framework/processing/worker_engine.ts
+++ b/packages/feldspar/src/framework/processing/worker_engine.ts
@@ -1,5 +1,5 @@
 import { CommandHandler } from '../types/modules'
-import { CommandSystemEvent, isCommand, Response } from '../types/commands'
+import { CommandSystemEvent, CommandSystemLog, isCommand, Response } from '../types/commands'
 
 export default class WorkerProcessingEngine  {
   sessionId: String
@@ -46,12 +46,44 @@ export default class WorkerProcessingEngine  {
         console.log('[ReactEngine] received: event', event.data.scriptEvent)
         this.handleRunCycle(event.data.scriptEvent)
         break
+
+      case 'error':
+        console.error(
+          '[ReactEngine] worker error:',
+          event.data.error,
+          event.data.stack
+        )
+        this.handleWorkerError(event.data.error, event.data.stack)
+        break
+
+      case 'workerLog':
+        this.forwardWorkerLog(event.data.level, event.data.message)
+        break
+
       default:
         console.log(
           '[ReactEngine] received unsupported flow event: ',
           eventType
         )
     }
+  }
+
+  handleWorkerError (error: string, stack: string): void {
+    const message = `[Worker] Error in runCycle: ${error}${stack ? `\n${stack}` : ''}`
+    this.forwardWorkerLog('error', message)
+  }
+
+  forwardWorkerLog (level: string, message: string): void {
+    const command: CommandSystemLog = {
+      __type__: 'CommandSystemLog',
+      level,
+      message,
+      json_string: JSON.stringify({ level, message })
+    }
+    this.commandHandler.onCommand(command).then(
+      () => {},
+      () => {}
+    )
   }
 
   start (): void {

--- a/packages/python/port/script.py
+++ b/packages/python/port/script.py
@@ -119,6 +119,8 @@ def get_timestamp(data, *key_path):
 
 def get_in(data_dict, *key_path):
     for k in key_path:
+        if not isinstance(data_dict, dict):
+            return None
         data_dict = data_dict.get(k, None)
         if data_dict is None:
             return None

--- a/packages/python/port/script.py
+++ b/packages/python/port/script.py
@@ -274,14 +274,16 @@ def extract_event_timestamp(item):
 
     Tries, in order:
     1. newer flat shape: item["timestamp"]
-    2. legacy string_list wrapper: item["string_list_data"][0]["timestamp"]
-    3. legacy string_map wrapper: item["string_map_data"]["Time"]["timestamp"]
+    2. newer flat shape (content): item["creation_timestamp"]
+    3. legacy string_list wrapper: item["string_list_data"][0]["timestamp"]
+    4. legacy string_map wrapper: item["string_map_data"]["Time"]["timestamp"]
     """
     if not isinstance(item, dict):
         return None
-    ts = get_timestamp(item, "timestamp")
-    if ts is not None:
-        return ts
+    for flat_key in ("timestamp", "creation_timestamp"):
+        ts = get_timestamp(item, flat_key)
+        if ts is not None:
+            return ts
     entries = get_in(item, "string_list_data")
     if isinstance(entries, list) and entries:
         ts = get_timestamp(entries[0], "timestamp")
@@ -293,16 +295,7 @@ def extract_event_timestamp(item):
 def count_items(zipfile, pattern, key=None):
     count = 0
     for data in glob_json(zipfile, pattern):
-        if key is None:
-            # Sum len of each record (used by followers/following counters)
-            if isinstance(data, dict):
-                data = [data]
-            for item in data:
-                if isinstance(item, (dict, list, str)):
-                    count += len(item)
-        else:
-            # Event-list counting — works for both shapes
-            count += len(_resolve_event_list(data, key))
+        count += len(_resolve_event_list(data, key))
     return count
 
 
@@ -559,15 +552,22 @@ def extract_direct_message_activity(zipfile):
 def flatten_media(media):
     if isinstance(media, list):
         for item in media:
-            if isinstance(item, dict) and isinstance(item.get("media"), list):
-                yield from item["media"]
+            if not isinstance(item, dict):
+                continue
+            nested = item.get("media")
+            if isinstance(nested, list):
+                # Legacy shape: media entries live in a nested "media" list.
+                yield from nested
+            else:
+                # Newer flat shape: the post itself carries the timestamp.
+                yield item
     else:
         yield media
 
 
 def get_creation_timestamps(items):
     for item in items:
-        ts = get_timestamp(item, "creation_timestamp")
+        ts = extract_event_timestamp(item)
         if ts is not None:
             yield ts
 
@@ -577,27 +577,24 @@ def get_media_creation_timestamps(items):
 
 
 def get_content_posts_timestamps(zipfile):
-    # Old format
-    for data in glob_json(zipfile, "*/content/posts_*.json"):
-
-        yield from get_media_creation_timestamps(data)
-    # New format: yield the first media item's timestamp per post
-    for data in glob_json(zipfile, "your_instagram_activity/media/posts_*.json"):
-        if not isinstance(data, list):
-            continue
-        for post in data:
-            media_list = get_in(post, "media") or []
-            for media in media_list:
-                ts = get_timestamp(media, "creation_timestamp")
-                if ts is not None:
-                    yield ts
-                    break
+    # Both legacy `*/content/posts_*.json` and newer
+    # `your_instagram_activity/media/posts_*.json` yield via the same
+    # flatten_media + get_creation_timestamps pipeline, which now handles:
+    #   - legacy post entries wrapping media[].creation_timestamp
+    #   - newer flat post entries with creation_timestamp/timestamp at root
+    for pattern in ("*/content/posts_*.json",
+                    "your_instagram_activity/media/posts_*.json"):
+        for data in glob_json(zipfile, pattern):
+            yield from get_media_creation_timestamps(data)
 
 
-def get_media_timestamps(zipfile, pattern, key):
-    for data in glob_json(zipfile, pattern):
-        items = _resolve_event_list(data, key)
-        yield from get_media_creation_timestamps(items)
+def get_media_timestamps(zipfile, patterns, key):
+    if isinstance(patterns, str):
+        patterns = (patterns,)
+    for pattern in patterns:
+        for data in glob_json(zipfile, pattern):
+            items = _resolve_event_list(data, key)
+            yield from get_media_creation_timestamps(items)
 
 
 def df_from_timestamps(timestamps, column):
@@ -652,8 +649,18 @@ def df_from_timestamp_columns(a, b):
 def get_video_posts_timestamps(zipfile):
     return itertools.chain(
         get_content_posts_timestamps(zipfile),
-        get_media_timestamps(zipfile, "*/content/igtv_videos.json", "ig_igtv_media"),
-        get_media_timestamps(zipfile, "*/content/reels.json", "ig_reels_media"),
+        get_media_timestamps(
+            zipfile,
+            ("*/content/igtv_videos.json",
+             "your_instagram_activity/media/igtv_videos.json"),
+            "ig_igtv_media",
+        ),
+        get_media_timestamps(
+            zipfile,
+            ("*/content/reels.json",
+             "your_instagram_activity/media/reels.json"),
+            "ig_reels_media",
+        ),
     )
 
 

--- a/packages/python/port/script.py
+++ b/packages/python/port/script.py
@@ -101,6 +101,22 @@ def parse_datetime(value):
     return uk_timezone.normalize(utc_datetime.astimezone(uk_timezone))
 
 
+def get_timestamp(data, *key_path):
+    """Navigate a nested dict path, then parse the leaf value as a timestamp.
+
+    Returns None if any intermediate key is missing, the final value is
+    None, or it isn't a parseable Unix timestamp. Used by the extraction
+    helpers so a malformed record is skipped rather than raising.
+    """
+    value = get_in(data, *key_path) if key_path else data
+    if value is None:
+        return None
+    try:
+        return parse_datetime(value)
+    except (TypeError, ValueError, OSError, OverflowError):
+        return None
+
+
 def get_in(data_dict, *key_path):
     for k in key_path:
         data_dict = data_dict.get(k, None)
@@ -237,10 +253,14 @@ def count_items(zipfile, pattern, key=None):
         if isinstance(data, dict):
             data = [data]
         for item in data:
+            if not isinstance(item, (dict, list, str)):
+                continue
             if key is None:
                 count += len(item)
             else:
-                count += len(item[key])
+                value = item.get(key) if isinstance(item, dict) else None
+                if value is not None:
+                    count += len(value)
     return count
 
 
@@ -256,22 +276,29 @@ def count_messages(zipfile):
     conversation_count = 0
     for data in glob_json(zipfile, "*/messages/inbox/**/message_*.json"):
         conversation_count += 1
-        try:
-            donating_user = get_donating_user(data)
-            msg_count = len(data.get("messages", []))
-            logger.debug(f"count_messages: Conversation {conversation_count} with user '{donating_user}', {msg_count} messages")
-            for message in data["messages"]:
-                key = "sent" if message.get("sender_name") == donating_user else "received"
-                counts[key] += 1
-        except Exception as e:
-            logger.warning(f"count_messages: Error processing conversation {conversation_count}: {e}")
+        donating_user = get_donating_user(data)
+        if donating_user is None:
+            logger.debug(f"count_messages: Conversation {conversation_count} has no identifiable donating user, skipping")
+            continue
+        messages = get_in(data, "messages") or []
+        logger.debug(f"count_messages: Conversation {conversation_count} with user '{donating_user}', {len(messages)} messages")
+        for message in messages:
+            if not isinstance(message, dict):
+                continue
+            key = "sent" if message.get("sender_name") == donating_user else "received"
+            counts[key] += 1
     logger.debug(f"count_messages: Processed {conversation_count} conversations, sent={counts['sent']}, received={counts['received']}")
     return counts
 
 
 def get_donating_user(data):
-    participants = data["participants"]
-    return participants[len(participants) - 1]["name"]
+    participants = data.get("participants") if isinstance(data, dict) else None
+    if not participants:
+        return None
+    last = participants[-1]
+    if not isinstance(last, dict):
+        return None
+    return last.get("name")
 
 
 def extract_summary_data(zipfile, locale="en"):
@@ -490,14 +517,17 @@ def extract_direct_message_activity(zipfile):
 def flatten_media(media):
     if isinstance(media, list):
         for item in media:
-            yield from item["media"]
+            if isinstance(item, dict) and isinstance(item.get("media"), list):
+                yield from item["media"]
     else:
         yield media
 
 
 def get_creation_timestamps(items):
     for item in items:
-        yield parse_datetime(item["creation_timestamp"])
+        ts = get_timestamp(item, "creation_timestamp")
+        if ts is not None:
+            yield ts
 
 
 def get_media_creation_timestamps(items):
@@ -509,17 +539,27 @@ def get_content_posts_timestamps(zipfile):
     for data in glob_json(zipfile, "*/content/posts_*.json"):
 
         yield from get_media_creation_timestamps(data)
-    # New format
+    # New format: yield the first media item's timestamp per post
     for data in glob_json(zipfile, "your_instagram_activity/media/posts_*.json"):
+        if not isinstance(data, list):
+            continue
         for post in data:
-            for media in post["media"]:
-                yield parse_datetime(media["creation_timestamp"])
-                break
+            media_list = get_in(post, "media") or []
+            for media in media_list:
+                ts = get_timestamp(media, "creation_timestamp")
+                if ts is not None:
+                    yield ts
+                    break
 
 
 def get_media_timestamps(zipfile, pattern, key):
     for data in glob_json(zipfile, pattern):
-        yield from get_media_creation_timestamps(data[key])
+        if not isinstance(data, dict):
+            continue
+        items = data.get(key)
+        if items is None:
+            continue
+        yield from get_media_creation_timestamps(items)
 
 
 def df_from_timestamps(timestamps, column):
@@ -532,15 +572,18 @@ def df_from_timestamps(timestamps, column):
 
 
 def stories_timestamps(zipfile):
-    # Old format
-    for data in glob_json(zipfile, "*/content/stories.json"):
-        for item in data["ig_stories"]:
-            yield parse_datetime(item["creation_timestamp"])
-
-    # New format
-    for data in glob_json(zipfile, "your_instagram_activity/media/stories.json"):
-        for item in data["ig_stories"]:
-            yield parse_datetime(item["creation_timestamp"])
+    patterns = (
+        "*/content/stories.json",
+        "your_instagram_activity/media/stories.json",
+    )
+    for pattern in patterns:
+        for data in glob_json(zipfile, pattern):
+            if not isinstance(data, dict):
+                continue
+            stories = data.get("ig_stories")
+            if not isinstance(stories, list):
+                continue
+            yield from get_creation_timestamps(stories)
             
 
 def df_from_timestamp_columns(a, b):
@@ -707,21 +750,32 @@ def get_post_comments_timestamps(zipfile):
 def get_string_map_timestamps(zipfile, pattern, key=None):
     for data in glob_json(zipfile, pattern):
         if key is not None:
-            data = data[key]
-        if isinstance(data, list):
-            for item in data:
-                yield parse_datetime(item["string_map_data"]["Time"]["timestamp"])
-        else:
-            yield parse_datetime(data["string_map_data"]["Time"]["timestamp"])
+            data = get_in(data, key)
+            if data is None:
+                continue
+        items = data if isinstance(data, list) else [data]
+        for item in items:
+            ts = get_timestamp(item, "string_map_data", "Time", "timestamp")
+            if ts is not None:
+                yield ts
 
 
 
 def get_string_list_timestamps(zipfile, pattern, key=None):
     for data in glob_json(zipfile, pattern):
         if key is not None:
-            data = data[key]
+            data = get_in(data, key)
+            if data is None:
+                continue
+        if not isinstance(data, list):
+            continue
         for item in data:
-            yield parse_datetime(item["string_list_data"][0]["timestamp"])
+            entries = get_in(item, "string_list_data") or []
+            if not entries:
+                continue
+            ts = get_timestamp(entries[0], "timestamp")
+            if ts is not None:
+                yield ts
 
 
 def get_likes_timestamps(zipfile):

--- a/packages/python/port/script.py
+++ b/packages/python/port/script.py
@@ -247,22 +247,62 @@ def map_to_timeslot(series):
     return series.map(lambda hour: f"{hour}-{hour+1}")
 
 
+def _resolve_event_list(data, key=None):
+    """Return the event list from a source file, tolerating both shapes.
+
+    - Newer shape: top-level list → return it
+    - Legacy shape: dict with the `key` well-known name → return dict[key]
+    - Legacy edge: dict representing a single event → return [data]
+    Returns [] when nothing matches.
+    """
+    if isinstance(data, list):
+        return data
+    if isinstance(data, dict):
+        if key is not None:
+            value = data.get(key)
+            if isinstance(value, list):
+                return value
+            if isinstance(value, dict):
+                return [value]
+            return []
+        return [data]
+    return []
+
+
+def extract_event_timestamp(item):
+    """Return a parsed timestamp from an event dict across known shapes.
+
+    Tries, in order:
+    1. newer flat shape: item["timestamp"]
+    2. legacy string_list wrapper: item["string_list_data"][0]["timestamp"]
+    3. legacy string_map wrapper: item["string_map_data"]["Time"]["timestamp"]
+    """
+    if not isinstance(item, dict):
+        return None
+    ts = get_timestamp(item, "timestamp")
+    if ts is not None:
+        return ts
+    entries = get_in(item, "string_list_data")
+    if isinstance(entries, list) and entries:
+        ts = get_timestamp(entries[0], "timestamp")
+        if ts is not None:
+            return ts
+    return get_timestamp(item, "string_map_data", "Time", "timestamp")
+
+
 def count_items(zipfile, pattern, key=None):
     count = 0
     for data in glob_json(zipfile, pattern):
-        # Some files have dictionary, others a list of dictionaries. Normalize
-        # this to always a list so the rest of the code works regardless.
-        if isinstance(data, dict):
-            data = [data]
-        for item in data:
-            if not isinstance(item, (dict, list, str)):
-                continue
-            if key is None:
-                count += len(item)
-            else:
-                value = item.get(key) if isinstance(item, dict) else None
-                if value is not None:
-                    count += len(value)
+        if key is None:
+            # Sum len of each record (used by followers/following counters)
+            if isinstance(data, dict):
+                data = [data]
+            for item in data:
+                if isinstance(item, (dict, list, str)):
+                    count += len(item)
+        else:
+            # Event-list counting — works for both shapes
+            count += len(_resolve_event_list(data, key))
     return count
 
 
@@ -556,11 +596,7 @@ def get_content_posts_timestamps(zipfile):
 
 def get_media_timestamps(zipfile, pattern, key):
     for data in glob_json(zipfile, pattern):
-        if not isinstance(data, dict):
-            continue
-        items = data.get(key)
-        if items is None:
-            continue
+        items = _resolve_event_list(data, key)
         yield from get_media_creation_timestamps(items)
 
 
@@ -580,12 +616,10 @@ def stories_timestamps(zipfile):
     )
     for pattern in patterns:
         for data in glob_json(zipfile, pattern):
-            if not isinstance(data, dict):
-                continue
-            stories = data.get("ig_stories")
-            if not isinstance(stories, list):
-                continue
-            yield from get_creation_timestamps(stories)
+            # Legacy: {"ig_stories": [...]}.  Newer (hypothetical): top-level list.
+            yield from get_creation_timestamps(
+                _resolve_event_list(data, "ig_stories")
+            )
             
 
 def df_from_timestamp_columns(a, b):
@@ -750,34 +784,19 @@ def get_post_comments_timestamps(zipfile):
 
 
 def get_string_map_timestamps(zipfile, pattern, key=None):
+    # Shape-agnostic: tries flat + legacy nested shapes per event.
     for data in glob_json(zipfile, pattern):
-        if key is not None:
-            data = get_in(data, key)
-            if data is None:
-                continue
-        items = data if isinstance(data, list) else [data]
-        for item in items:
-            ts = get_timestamp(item, "string_map_data", "Time", "timestamp")
+        for item in _resolve_event_list(data, key):
+            ts = extract_event_timestamp(item)
             if ts is not None:
                 yield ts
-
 
 
 def get_string_list_timestamps(zipfile, pattern, key=None):
-    for data in glob_json(zipfile, pattern):
-        if key is not None:
-            data = get_in(data, key)
-            if data is None:
-                continue
-        if not isinstance(data, list):
-            continue
-        for item in data:
-            entries = get_in(item, "string_list_data") or []
-            if not entries:
-                continue
-            ts = get_timestamp(entries[0], "timestamp")
-            if ts is not None:
-                yield ts
+    # Shape-agnostic — same logic as get_string_map_timestamps. The
+    # two historically distinguished which nested wrapper to expect;
+    # extract_event_timestamp now tries both plus the newer flat shape.
+    yield from get_string_map_timestamps(zipfile, pattern, key)
 
 
 def get_likes_timestamps(zipfile):

--- a/packages/python/tests/fixtures.py
+++ b/packages/python/tests/fixtures.py
@@ -336,6 +336,14 @@ def write_newer_format_folder(out_dir, scale="realistic", seed=None):
          for t in _random_timestamps(rng, cfg["liked_comments"])],
     )
 
+    # comments — top-level list + flat `timestamp`.  (Order matches the
+    # legacy writer so the RNG streams stay aligned: conversations →
+    # ads_and_topics → likes → comments → content.)
+    _dump(
+        _abspath("your_instagram_activity", "comments", "post_comments_1.json"),
+        [_newer_flat_event(t) for t in _random_timestamps(rng, cfg["comments"])],
+    )
+
     # content (posts / stories / igtv / reels) — top-level list +
     # flat `creation_timestamp`. Paths live under the newer
     # `your_instagram_activity/media/...` location.
@@ -350,12 +358,6 @@ def write_newer_format_folder(out_dir, scale="realistic", seed=None):
             [{"creation_timestamp": t}
              for t in _random_timestamps(rng, count)],
         )
-
-    # comments — top-level list + flat `timestamp`
-    _dump(
-        _abspath("your_instagram_activity", "comments", "post_comments_1.json"),
-        [_newer_flat_event(t) for t in _random_timestamps(rng, cfg["comments"])],
-    )
 
     # Followers / following still use the legacy summary shape — the
     # newer shape for these is unconfirmed against a participant zip.
@@ -402,7 +404,10 @@ def write_legacy_format_folder(out_dir, scale="realistic", seed=None):
 
     donor = _fake_name(rng)
     # Top-level prefix mirrors real exports like `instagram_username_YYYYMMDD/`.
-    prefix = f"instagram_fixture_{rng.randrange(10**6):06d}"
+    # Kept constant so the RNG stream stays aligned with write_newer_format_folder
+    # — that way a given (scale, seed) yields identical event counts in both
+    # fixtures.
+    prefix = "instagram_fixture"
 
     def _abspath(*parts):
         path = os.path.join(out_dir, prefix, *parts)

--- a/packages/python/tests/fixtures.py
+++ b/packages/python/tests/fixtures.py
@@ -205,13 +205,19 @@ def make_legacy_format_zip():
 
 _SCALES = {
     "small": dict(conversations=2, messages_per=5, videos=10, posts=5, ads=2,
-                  likes=7, followers=4, following=3),
+                  likes=7, followers=4, following=3,
+                  content_posts=3, stories=3, igtv=1, reels=2,
+                  comments=5, liked_comments=3),
     "realistic": dict(conversations=11, messages_per=(20, 80), videos=800,
                       posts=250, ads=40, likes=40, followers=120,
-                      following=160),
+                      following=160,
+                      content_posts=20, stories=15, igtv=5, reels=10,
+                      comments=50, liked_comments=30),
     "large": dict(conversations=50, messages_per=(50, 400), videos=5000,
                   posts=1500, ads=300, likes=400, followers=1200,
-                  following=1500),
+                  following=1500,
+                  content_posts=200, stories=150, igtv=50, reels=100,
+                  comments=500, liked_comments=300),
 }
 
 
@@ -328,20 +334,157 @@ def write_newer_format_folder(out_dir, scale="realistic", seed=None):
     return os.path.abspath(out_dir)
 
 
+def write_legacy_format_folder(out_dir, scale="realistic", seed=None):
+    """Write a folder tree of bogus Instagram-legacy-format files to disk.
+
+    The legacy format wraps each event-list in a dict keyed by a
+    per-source well-known name (e.g. `likes_media_likes`) and hides
+    timestamps under `string_list_data[0].timestamp` or
+    `string_map_data.Time.timestamp`. Content posts / stories / reels
+    are included too so extract_data has non-empty video_posts and
+    comments_and_likes tables.
+
+    Returns the absolute out_dir path.
+    """
+    if scale not in _SCALES:
+        raise ValueError(f"unknown scale {scale!r}; expected one of {sorted(_SCALES)}")
+    cfg = _SCALES[scale]
+    rng = random.Random(seed)
+
+    donor = _fake_name(rng)
+    # Top-level prefix mirrors real exports like `instagram_username_YYYYMMDD/`.
+    prefix = f"instagram_fixture_{rng.randrange(10**6):06d}"
+
+    def _abspath(*parts):
+        path = os.path.join(out_dir, prefix, *parts)
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        return path
+
+    def _dump(path, obj):
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(obj, f, ensure_ascii=False, indent=2)
+
+    # Message conversations (same shape as newer)
+    for _ in range(cfg["conversations"]):
+        other = _fake_name(rng)
+        slug = f"{other.split()[0].lower()}_{rng.randrange(10**15, 10**16)}"
+        msg_count = _resolve_messages_per(rng, cfg["messages_per"])
+        timestamps = _random_timestamps(rng, msg_count, span_days=90)
+        _dump(
+            _abspath("messages", "inbox", slug, "message_1.json"),
+            {
+                "participants": [{"name": other}, {"name": donor}],
+                "messages": [
+                    {"sender_name": rng.choice([other, donor]),
+                     "timestamp_ms": t * 1000}
+                    for t in timestamps
+                ],
+                "title": other,
+                "is_still_participant": True,
+                "thread_path": f"inbox/{slug}",
+            },
+        )
+
+    # ads_and_topics — dict wrapper + string_map_data nesting
+    _dump(
+        _abspath("ads_and_topics", "videos_watched.json"),
+        {"impressions_history_videos_watched":
+            [_legacy_string_map_entry(t)
+             for t in _random_timestamps(rng, cfg["videos"])]},
+    )
+    _dump(
+        _abspath("ads_and_topics", "posts_viewed.json"),
+        {"impressions_history_posts_seen":
+            [_legacy_string_map_entry(t)
+             for t in _random_timestamps(rng, cfg["posts"])]},
+    )
+    _dump(
+        _abspath("ads_and_topics", "ads_viewed.json"),
+        {"impressions_history_ads_seen":
+            [_legacy_string_map_entry(t)
+             for t in _random_timestamps(rng, cfg["ads"])]},
+    )
+
+    # likes — dict wrapper + string_list_data nesting
+    _dump(
+        _abspath("likes", "liked_posts.json"),
+        {"likes_media_likes":
+            [_legacy_string_list_entry(t)
+             for t in _random_timestamps(rng, cfg["likes"])]},
+    )
+    _dump(
+        _abspath("likes", "liked_comments.json"),
+        {"likes_comment_likes":
+            [_legacy_string_list_entry(t)
+             for t in _random_timestamps(rng, cfg["liked_comments"])]},
+    )
+
+    # comments (list of string_map entries)
+    _dump(
+        _abspath("comments", "post_comments_1.json"),
+        [_legacy_string_map_entry(t)
+         for t in _random_timestamps(rng, cfg["comments"])],
+    )
+
+    # content — posts, stories, igtv, reels (each have creation_timestamp)
+    def _flat_ts_list(key, count):
+        return [{"creation_timestamp": t}
+                for t in _random_timestamps(rng, count)]
+
+    _dump(
+        _abspath("content", "posts_1.json"),
+        [{"media": [{"creation_timestamp": t}]}
+         for t in _random_timestamps(rng, cfg["content_posts"])],
+    )
+    _dump(
+        _abspath("content", "stories.json"),
+        {"ig_stories": _flat_ts_list("creation_timestamp", cfg["stories"])},
+    )
+    _dump(
+        _abspath("content", "igtv_videos.json"),
+        {"ig_igtv_media": _flat_ts_list("creation_timestamp", cfg["igtv"])},
+    )
+    _dump(
+        _abspath("content", "reels.json"),
+        {"ig_reels_media": _flat_ts_list("creation_timestamp", cfg["reels"])},
+    )
+
+    # followers / following — same shape as newer writer
+    _dump(
+        _abspath("followers_and_following", "followers_1.json"),
+        {"string_list_data": [
+            {"value": f"user_{rng.randrange(10**9)}"}
+            for _ in range(cfg["followers"])]},
+    )
+    _dump(
+        _abspath("followers_and_following", "following.json"),
+        {"relationships_following": [
+            {"string_list_data": [{"value": f"user_{rng.randrange(10**9)}"}]}
+            for _ in range(cfg["following"])]},
+    )
+
+    return os.path.abspath(out_dir)
+
+
 def main():
     import argparse
     parser = argparse.ArgumentParser(
-        description="Generate a bogus Instagram newer-format export folder.",
+        description="Generate a bogus Instagram export folder "
+                    "(newer or legacy format).",
     )
     parser.add_argument("out_dir", help="target folder (created if missing)")
+    parser.add_argument("--format", default="newer",
+                        choices=["newer", "legacy"],
+                        help="which Instagram export shape to emit")
     parser.add_argument("--scale", default="realistic",
                         choices=sorted(_SCALES.keys()))
     parser.add_argument("--seed", type=int, default=None,
                         help="int seed for reproducibility (default: random)")
     args = parser.parse_args()
-    path = write_newer_format_folder(args.out_dir, scale=args.scale,
-                                     seed=args.seed)
-    print(f"Wrote fixture to {path}")
+    writer = (write_newer_format_folder if args.format == "newer"
+              else write_legacy_format_folder)
+    path = writer(args.out_dir, scale=args.scale, seed=args.seed)
+    print(f"Wrote {args.format} fixture to {path}")
 
 
 if __name__ == "__main__":

--- a/packages/python/tests/fixtures.py
+++ b/packages/python/tests/fixtures.py
@@ -21,6 +21,7 @@ responsible for unlinking the file.
 
 import json
 import os
+import random
 import tempfile
 import zipfile
 
@@ -28,6 +29,20 @@ import zipfile
 # Deterministic Unix timestamps so tests can assert counts and ranges.
 # 2026-01-01 00:00:00 UTC == 1767225600
 _BASE_TS = 1767225600
+
+# Bogus name pools for randomized fixtures.
+_FIRST_NAMES = [
+    "Alex", "Bailey", "Casey", "Dakota", "Ellis", "Frankie", "Gray",
+    "Harper", "Indigo", "Jules", "Kai", "Logan", "Morgan", "Nova",
+    "Oakley", "Parker", "Quinn", "Reese", "Sage", "Taylor", "Unity",
+    "Val", "Wren", "Xen", "Yuki", "Zephyr",
+]
+_LAST_NAMES = [
+    "Ash", "Brook", "Cole", "Drew", "East", "Fern", "Glen",
+    "Hale", "Isle", "Jade", "Knox", "Lark", "Moss", "North",
+    "Orr", "Pine", "Quill", "Rook", "Sable", "Teal", "Vale",
+    "Wade", "Yale", "Zane",
+]
 
 
 def _ts(offset_hours):
@@ -182,3 +197,152 @@ def make_legacy_format_zip():
         },
     }
     return _write_zip(files)
+
+
+# ---------------------------------------------------------------------------
+# Realistic-scale random fixture (written to a folder on disk)
+# ---------------------------------------------------------------------------
+
+_SCALES = {
+    "small": dict(conversations=2, messages_per=5, videos=10, posts=5, ads=2,
+                  likes=7, followers=4, following=3),
+    "realistic": dict(conversations=11, messages_per=(20, 80), videos=800,
+                      posts=250, ads=40, likes=40, followers=120,
+                      following=160),
+    "large": dict(conversations=50, messages_per=(50, 400), videos=5000,
+                  posts=1500, ads=300, likes=400, followers=1200,
+                  following=1500),
+}
+
+
+def _fake_name(rng):
+    return f"{rng.choice(_FIRST_NAMES)} {rng.choice(_LAST_NAMES)}"
+
+
+def _random_timestamps(rng, count, span_days=180):
+    """Return `count` ascending uniformly-random Unix timestamps."""
+    span_seconds = span_days * 24 * 3600
+    return sorted(rng.randint(_BASE_TS, _BASE_TS + span_seconds)
+                  for _ in range(count))
+
+
+def _resolve_messages_per(rng, spec):
+    if isinstance(spec, tuple):
+        lo, hi = spec
+        return rng.randint(lo, hi)
+    return spec
+
+
+def write_newer_format_folder(out_dir, scale="realistic", seed=None):
+    """Write a folder tree of bogus Instagram-newer-format files to disk.
+
+    Args:
+        out_dir: target directory. Created if missing. Existing contents
+            are not cleared.
+        scale: "small" / "realistic" / "large" — see _SCALES for counts.
+        seed: int for reproducibility (None = truly random).
+
+    Returns the absolute out_dir path.
+    """
+    if scale not in _SCALES:
+        raise ValueError(f"unknown scale {scale!r}; expected one of {sorted(_SCALES)}")
+    cfg = _SCALES[scale]
+    rng = random.Random(seed)
+
+    donor = _fake_name(rng)
+
+    def _abspath(*parts):
+        path = os.path.join(out_dir, *parts)
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        return path
+
+    def _dump(path, obj):
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(obj, f, ensure_ascii=False, indent=2)
+
+    # Message conversations (newer format: inbox/<slug>/message_1.json)
+    for _ in range(cfg["conversations"]):
+        other = _fake_name(rng)
+        slug = f"{other.split()[0].lower()}_{rng.randrange(10**15, 10**16)}"
+        msg_count = _resolve_messages_per(rng, cfg["messages_per"])
+        timestamps = _random_timestamps(rng, msg_count, span_days=90)
+        messages = [
+            {
+                "sender_name": rng.choice([other, donor]),
+                "timestamp_ms": t * 1000,
+            }
+            for t in timestamps
+        ]
+        _dump(
+            _abspath("your_instagram_activity", "messages", "inbox", slug,
+                    "message_1.json"),
+            {
+                "participants": [{"name": other}, {"name": donor}],
+                "messages": messages,
+                "title": other,
+                "is_still_participant": True,
+                "thread_path": f"inbox/{slug}",
+                "magic_words": [],
+            },
+        )
+
+    # Newer-format top-level-list files
+    for name, count in [
+        ("videos_watched.json", cfg["videos"]),
+        ("posts_viewed.json", cfg["posts"]),
+        ("ads_viewed.json", cfg["ads"]),
+    ]:
+        _dump(
+            _abspath("ads_information", "ads_and_topics", name),
+            [_newer_flat_event(t) for t in _random_timestamps(rng, count)],
+        )
+
+    _dump(
+        _abspath("your_instagram_activity", "likes", "liked_posts.json"),
+        [_newer_flat_event(t) for t in _random_timestamps(rng, cfg["likes"])],
+    )
+
+    # Followers / following still use the legacy summary shape — the
+    # newer shape for these is unconfirmed against a participant zip.
+    _dump(
+        _abspath("connections", "followers_and_following", "followers_1.json"),
+        {
+            "string_list_data": [
+                {"value": f"user_{rng.randrange(10**9)}"}
+                for _ in range(cfg["followers"])
+            ],
+        },
+    )
+    _dump(
+        _abspath("connections", "followers_and_following", "following.json"),
+        {
+            "relationships_following": [
+                {"string_list_data": [
+                    {"value": f"user_{rng.randrange(10**9)}"}
+                ]}
+                for _ in range(cfg["following"])
+            ],
+        },
+    )
+
+    return os.path.abspath(out_dir)
+
+
+def main():
+    import argparse
+    parser = argparse.ArgumentParser(
+        description="Generate a bogus Instagram newer-format export folder.",
+    )
+    parser.add_argument("out_dir", help="target folder (created if missing)")
+    parser.add_argument("--scale", default="realistic",
+                        choices=sorted(_SCALES.keys()))
+    parser.add_argument("--seed", type=int, default=None,
+                        help="int seed for reproducibility (default: random)")
+    args = parser.parse_args()
+    path = write_newer_format_folder(args.out_dir, scale=args.scale,
+                                     seed=args.seed)
+    print(f"Wrote fixture to {path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/python/tests/fixtures.py
+++ b/packages/python/tests/fixtures.py
@@ -1,0 +1,184 @@
+"""Helpers that build Instagram export fixtures for tests.
+
+Everything in here is fabricated data — no PII. The fixtures reproduce
+the structural shape of real Instagram exports so the extraction code
+can be exercised without needing a participant zip.
+
+Two formats are covered:
+
+- `make_legacy_format_zip` — the older shape, where list-of-events files
+  are wrapped in a dict with a well-known key (e.g. `likes_media_likes`)
+  and each event's timestamp lives under `string_list_data[0].timestamp`
+  or `string_map_data.Time.timestamp`.
+
+- `make_newer_format_zip` — the newer shape Instagram started exporting
+  in 2026, where those same files are top-level lists and each entry
+  carries `timestamp` directly at the root.
+
+Both functions return the absolute path to a tempfile zip. Callers are
+responsible for unlinking the file.
+"""
+
+import json
+import os
+import tempfile
+import zipfile
+
+
+# Deterministic Unix timestamps so tests can assert counts and ranges.
+# 2026-01-01 00:00:00 UTC == 1767225600
+_BASE_TS = 1767225600
+
+
+def _ts(offset_hours):
+    return _BASE_TS + offset_hours * 3600
+
+
+def _timestamp_list(count, start_offset_hours=0):
+    """Return `count` ascending timestamps, one per hour."""
+    return [_ts(start_offset_hours + i) for i in range(count)]
+
+
+def _write_zip(files):
+    """Write a dict of {path: json_value_or_str} to a new tempfile zip."""
+    fd, path = tempfile.mkstemp(suffix=".zip")
+    os.close(fd)
+    with zipfile.ZipFile(path, "w") as zf:
+        for name, content in files.items():
+            if isinstance(content, (bytes, str)):
+                zf.writestr(name, content)
+            else:
+                zf.writestr(name, json.dumps(content))
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Newer format (2026+)
+# ---------------------------------------------------------------------------
+
+def _newer_message_file(participant_names, message_count, start_offset_hours=0):
+    """Build one message_1.json in the newer format.
+
+    `participant_names[-1]` is the donating user (Instagram's convention).
+    """
+    timestamps_ms = [t * 1000 for t in _timestamp_list(message_count, start_offset_hours)]
+    # Alternate senders so both participants get messages.
+    messages = [
+        {
+            "sender_name": participant_names[i % len(participant_names)],
+            "timestamp_ms": timestamps_ms[i],
+        }
+        for i in range(message_count)
+    ]
+    return {
+        "participants": [{"name": n} for n in participant_names],
+        "messages": messages,
+        "title": participant_names[0],
+        "is_still_participant": True,
+        "thread_path": "inbox/conversation",
+        "magic_words": [],
+    }
+
+
+def _newer_flat_event(ts):
+    """A single entry in the newer top-level-list format."""
+    return {"timestamp": ts, "media": [], "label_values": []}
+
+
+def make_newer_format_zip():
+    """Create a zip that mirrors the newer Instagram export shape.
+
+    Returns the absolute path to the zip. Callers must unlink it.
+
+    Contents (all counts are small but non-trivial so tests can assert):
+      - 2 message threads (5 + 3 messages = 8 total messages)
+      - 10 videos_watched entries
+      - 5 posts_viewed entries
+      - 2 ads_viewed entries
+      - 7 liked_posts entries
+      - 3 following + 4 followers (summary counts)
+    """
+    files = {
+        "your_instagram_activity/messages/inbox/conv_a_1111/message_1.json":
+            _newer_message_file(["Alice Test", "Donor User"], message_count=5,
+                                start_offset_hours=0),
+        "your_instagram_activity/messages/inbox/conv_b_2222/message_1.json":
+            _newer_message_file(["Bob Test", "Donor User"], message_count=3,
+                                start_offset_hours=10),
+
+        "ads_information/ads_and_topics/videos_watched.json":
+            [_newer_flat_event(t) for t in _timestamp_list(10, 100)],
+        "ads_information/ads_and_topics/posts_viewed.json":
+            [_newer_flat_event(t) for t in _timestamp_list(5, 200)],
+        "ads_information/ads_and_topics/ads_viewed.json":
+            [_newer_flat_event(t) for t in _timestamp_list(2, 300)],
+
+        "your_instagram_activity/likes/liked_posts.json":
+            [_newer_flat_event(t) for t in _timestamp_list(7, 400)],
+
+        # Summary inputs — followers/following are still counted, so we
+        # need something the existing counter understands. The newer
+        # shape for these has not been observed yet; using legacy shape
+        # here until a participant zip clarifies it.
+        "connections/followers_and_following/followers_1.json": {
+            "string_list_data": [
+                {"value": f"follower_{i}"} for i in range(4)
+            ]
+        },
+        "connections/followers_and_following/following.json": {
+            "relationships_following": [
+                {"string_list_data": [{"value": f"following_{i}"}]}
+                for i in range(3)
+            ]
+        },
+    }
+    return _write_zip(files)
+
+
+# ---------------------------------------------------------------------------
+# Legacy format — keep a helper too so regression tests can compare
+# ---------------------------------------------------------------------------
+
+def _legacy_string_list_entry(ts):
+    return {"string_list_data": [{"timestamp": ts, "value": "x"}]}
+
+
+def _legacy_string_map_entry(ts):
+    return {"string_map_data": {"Time": {"timestamp": ts}}}
+
+
+def make_legacy_format_zip():
+    """Create a zip in the legacy (pre-2026) Instagram export shape."""
+    files = {
+        "test/messages/inbox/conv_a/message_1.json":
+            _newer_message_file(["Alice Test", "Donor User"], message_count=5),
+
+        "test/ads_and_topics/videos_watched.json": {
+            "impressions_history_videos_watched":
+                [_legacy_string_map_entry(t) for t in _timestamp_list(10, 100)],
+        },
+        "test/ads_and_topics/posts_viewed.json": {
+            "impressions_history_posts_seen":
+                [_legacy_string_map_entry(t) for t in _timestamp_list(5, 200)],
+        },
+        "test/ads_and_topics/ads_viewed.json": {
+            "impressions_history_ads_seen":
+                [_legacy_string_map_entry(t) for t in _timestamp_list(2, 300)],
+        },
+
+        "test/likes/liked_posts.json": {
+            "likes_media_likes":
+                [_legacy_string_list_entry(t) for t in _timestamp_list(7, 400)],
+        },
+
+        "test/followers_and_following/followers_1.json": {
+            "string_list_data": [{"value": f"follower_{i}"} for i in range(4)],
+        },
+        "test/followers_and_following/following.json": {
+            "relationships_following": [
+                {"string_list_data": [{"value": f"following_{i}"}]}
+                for i in range(3)
+            ],
+        },
+    }
+    return _write_zip(files)

--- a/packages/python/tests/fixtures.py
+++ b/packages/python/tests/fixtures.py
@@ -466,6 +466,19 @@ def write_legacy_format_folder(out_dir, scale="realistic", seed=None):
     return os.path.abspath(out_dir)
 
 
+def _zip_folder(folder):
+    """Zip `folder` to sibling `<folder>.zip`. Returns zip path."""
+    zip_path = folder.rstrip("/") + ".zip"
+    if os.path.exists(zip_path):
+        os.unlink(zip_path)
+    with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zf:
+        for root, _, files in os.walk(folder):
+            for name in files:
+                full = os.path.join(root, name)
+                zf.write(full, os.path.relpath(full, folder))
+    return zip_path
+
+
 def main():
     import argparse
     parser = argparse.ArgumentParser(
@@ -480,11 +493,16 @@ def main():
                         choices=sorted(_SCALES.keys()))
     parser.add_argument("--seed", type=int, default=None,
                         help="int seed for reproducibility (default: random)")
+    parser.add_argument("--zip", action="store_true",
+                        help="also emit <out_dir>.zip alongside the folder")
     args = parser.parse_args()
     writer = (write_newer_format_folder if args.format == "newer"
               else write_legacy_format_folder)
     path = writer(args.out_dir, scale=args.scale, seed=args.seed)
     print(f"Wrote {args.format} fixture to {path}")
+    if args.zip:
+        zip_path = _zip_folder(path)
+        print(f"Zipped to {zip_path}")
 
 
 if __name__ == "__main__":

--- a/packages/python/tests/fixtures.py
+++ b/packages/python/tests/fixtures.py
@@ -100,18 +100,24 @@ def _newer_flat_event(ts):
     return {"timestamp": ts, "media": [], "label_values": []}
 
 
+def _newer_creation_event(ts):
+    """A single content entry in the newer flat shape."""
+    return {"creation_timestamp": ts}
+
+
 def make_newer_format_zip():
     """Create a zip that mirrors the newer Instagram export shape.
 
-    Returns the absolute path to the zip. Callers must unlink it.
+    All source files the extractor reads are represented with their
+    newer shape (top-level list, flat `timestamp` / `creation_timestamp`).
 
-    Contents (all counts are small but non-trivial so tests can assert):
-      - 2 message threads (5 + 3 messages = 8 total messages)
-      - 10 videos_watched entries
-      - 5 posts_viewed entries
-      - 2 ads_viewed entries
-      - 7 liked_posts entries
-      - 3 following + 4 followers (summary counts)
+    Contents:
+      - 2 message threads (5 + 3 = 8 messages)
+      - ads_and_topics: 10 videos_watched, 5 posts_viewed, 2 ads_viewed
+      - likes: 7 liked_posts, 4 liked_comments
+      - content: 6 posts, 4 stories, 2 igtv_videos, 3 reels
+      - 9 post_comments
+      - 3 following + 4 followers
     """
     files = {
         "your_instagram_activity/messages/inbox/conv_a_1111/message_1.json":
@@ -121,6 +127,7 @@ def make_newer_format_zip():
             _newer_message_file(["Bob Test", "Donor User"], message_count=3,
                                 start_offset_hours=10),
 
+        # ads_and_topics — top-level list + flat `timestamp`
         "ads_information/ads_and_topics/videos_watched.json":
             [_newer_flat_event(t) for t in _timestamp_list(10, 100)],
         "ads_information/ads_and_topics/posts_viewed.json":
@@ -128,13 +135,28 @@ def make_newer_format_zip():
         "ads_information/ads_and_topics/ads_viewed.json":
             [_newer_flat_event(t) for t in _timestamp_list(2, 300)],
 
+        # likes — top-level list + flat `timestamp`
         "your_instagram_activity/likes/liked_posts.json":
             [_newer_flat_event(t) for t in _timestamp_list(7, 400)],
+        "your_instagram_activity/likes/liked_comments.json":
+            [_newer_flat_event(t) for t in _timestamp_list(4, 500)],
 
-        # Summary inputs — followers/following are still counted, so we
-        # need something the existing counter understands. The newer
-        # shape for these has not been observed yet; using legacy shape
-        # here until a participant zip clarifies it.
+        # content — top-level list + flat `creation_timestamp`
+        "your_instagram_activity/media/posts_1.json":
+            [_newer_creation_event(t) for t in _timestamp_list(6, 600)],
+        "your_instagram_activity/media/stories.json":
+            [_newer_creation_event(t) for t in _timestamp_list(4, 700)],
+        "your_instagram_activity/media/igtv_videos.json":
+            [_newer_creation_event(t) for t in _timestamp_list(2, 800)],
+        "your_instagram_activity/media/reels.json":
+            [_newer_creation_event(t) for t in _timestamp_list(3, 900)],
+
+        # comments — top-level list + flat `timestamp`
+        "your_instagram_activity/comments/post_comments_1.json":
+            [_newer_flat_event(t) for t in _timestamp_list(9, 1000)],
+
+        # Followers/following — newer shape not yet observed in a real
+        # export; keep the legacy shape here until we have evidence.
         "connections/followers_and_following/followers_1.json": {
             "string_list_data": [
                 {"value": f"follower_{i}"} for i in range(4)
@@ -292,7 +314,7 @@ def write_newer_format_folder(out_dir, scale="realistic", seed=None):
             },
         )
 
-    # Newer-format top-level-list files
+    # ads_and_topics — top-level list + flat `timestamp`
     for name, count in [
         ("videos_watched.json", cfg["videos"]),
         ("posts_viewed.json", cfg["posts"]),
@@ -303,9 +325,36 @@ def write_newer_format_folder(out_dir, scale="realistic", seed=None):
             [_newer_flat_event(t) for t in _random_timestamps(rng, count)],
         )
 
+    # likes — top-level list + flat `timestamp`
     _dump(
         _abspath("your_instagram_activity", "likes", "liked_posts.json"),
         [_newer_flat_event(t) for t in _random_timestamps(rng, cfg["likes"])],
+    )
+    _dump(
+        _abspath("your_instagram_activity", "likes", "liked_comments.json"),
+        [_newer_flat_event(t)
+         for t in _random_timestamps(rng, cfg["liked_comments"])],
+    )
+
+    # content (posts / stories / igtv / reels) — top-level list +
+    # flat `creation_timestamp`. Paths live under the newer
+    # `your_instagram_activity/media/...` location.
+    for name, count in [
+        ("posts_1.json", cfg["content_posts"]),
+        ("stories.json", cfg["stories"]),
+        ("igtv_videos.json", cfg["igtv"]),
+        ("reels.json", cfg["reels"]),
+    ]:
+        _dump(
+            _abspath("your_instagram_activity", "media", name),
+            [{"creation_timestamp": t}
+             for t in _random_timestamps(rng, count)],
+        )
+
+    # comments — top-level list + flat `timestamp`
+    _dump(
+        _abspath("your_instagram_activity", "comments", "post_comments_1.json"),
+        [_newer_flat_event(t) for t in _random_timestamps(rng, cfg["comments"])],
     )
 
     # Followers / following still use the legacy summary shape — the

--- a/packages/python/tests/test_defensive_key_access.py
+++ b/packages/python/tests/test_defensive_key_access.py
@@ -229,6 +229,19 @@ class TestGetStringListTimestampsDefensive:
         finally:
             os.unlink(path)
 
+    def test_top_level_is_list_when_key_expected(self):
+        # Reproduces a production crash: file's top level is a list, but
+        # caller passed a key expecting a dict. get_in must not AttributeError.
+        data = [{"string_list_data": [{"timestamp": 1640995200}]}]
+        path = make_zip({"test/likes/liked_posts.json": data})
+        try:
+            with zipfile.ZipFile(path) as zf:
+                result = list(get_string_list_timestamps(
+                    zf, "*/likes/liked_posts.json", "likes_media_likes"))
+            assert result == []
+        finally:
+            os.unlink(path)
+
 
 # ---------------------------------------------------------------------------
 # flatten_media

--- a/packages/python/tests/test_defensive_key_access.py
+++ b/packages/python/tests/test_defensive_key_access.py
@@ -229,10 +229,12 @@ class TestGetStringListTimestampsDefensive:
         finally:
             os.unlink(path)
 
-    def test_top_level_is_list_when_key_expected(self):
-        # Reproduces a production crash: file's top level is a list, but
-        # caller passed a key expecting a dict. get_in must not AttributeError.
-        data = [{"string_list_data": [{"timestamp": 1640995200}]}]
+    def test_top_level_list_with_no_extractable_timestamp(self):
+        # Originally guarded a get_in/list AttributeError. With shape
+        # detection a top-level list is now a valid (newer) shape, so
+        # extraction proceeds. The defensive case becomes: list data
+        # whose entries expose nothing recognizable as a timestamp.
+        data = [{"unrelated": True}, "not even a dict"]
         path = make_zip({"test/likes/liked_posts.json": data})
         try:
             with zipfile.ZipFile(path) as zf:

--- a/packages/python/tests/test_defensive_key_access.py
+++ b/packages/python/tests/test_defensive_key_access.py
@@ -250,17 +250,28 @@ class TestGetStringListTimestampsDefensive:
 # ---------------------------------------------------------------------------
 
 class TestFlattenMediaDefensive:
-    def test_list_item_missing_media_key(self):
-        result = list(flatten_media([{"not_media": []}]))
-        assert result == []
+    """flatten_media supports both shapes:
 
-    def test_list_mixed_valid_and_missing(self):
+    - Legacy: each item has a "media" list → yield from that list.
+    - Newer flat: no "media" key → yield the item itself (downstream
+      extract_event_timestamp will read its root-level creation_timestamp).
+    """
+
+    def test_list_item_without_media_yielded_as_is(self):
+        # The item has no "media" key, so it's treated as a flat-shape
+        # post and yielded directly. If it has no recognizable timestamp
+        # downstream, get_creation_timestamps will skip it anyway.
+        result = list(flatten_media([{"not_media": []}]))
+        assert result == [{"not_media": []}]
+
+    def test_list_mixed_nested_and_flat(self):
         result = list(flatten_media([
             {"media": [{"creation_timestamp": 1640995200}]},
-            {"not_media": []},
+            {"creation_timestamp": 1641000000},
             {"media": [{"creation_timestamp": 1641081600}]},
         ]))
-        assert len(result) == 2
+        # Two media entries + one flat entry = 3 items yielded.
+        assert len(result) == 3
 
 
 # ---------------------------------------------------------------------------

--- a/packages/python/tests/test_defensive_key_access.py
+++ b/packages/python/tests/test_defensive_key_access.py
@@ -1,0 +1,382 @@
+"""Tests covering defensive access patterns in extraction helpers.
+
+These tests exercise each unsafe subscript in script.py with real-world
+zipfile fixtures that are missing keys, have empty lists, or have the
+wrong shape. Each helper is expected to skip malformed records rather
+than raising KeyError / IndexError / TypeError.
+
+Issue 9804937176 — Defensive key access in extraction helpers.
+"""
+
+import json
+import os
+import sys
+import tempfile
+import zipfile
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "port"))
+
+from script import (  # noqa: E402
+    count_items,
+    count_messages,
+    flatten_media,
+    get_content_posts_timestamps,
+    get_creation_timestamps,
+    get_donating_user,
+    get_string_list_timestamps,
+    get_string_map_timestamps,
+    get_video_posts_timestamps,
+    stories_timestamps,
+)
+
+
+def make_zip(files):
+    """Create a tempfile zip containing the given {name: data} mapping.
+
+    Values can be a string (written verbatim) or JSON-serializable.
+    Returns the absolute path; caller is responsible for cleanup.
+    """
+    fd, path = tempfile.mkstemp(suffix=".zip")
+    os.close(fd)
+    with zipfile.ZipFile(path, "w") as zf:
+        for name, content in files.items():
+            if isinstance(content, str):
+                zf.writestr(name, content)
+            else:
+                zf.writestr(name, json.dumps(content))
+    return path
+
+
+# ---------------------------------------------------------------------------
+# count_items
+# ---------------------------------------------------------------------------
+
+class TestCountItems:
+    """count_items(zipfile, pattern, key) should tolerate a missing top-level key."""
+
+    def test_missing_key_in_dict_form(self):
+        # Real-world failure: ads_viewed.json exists but has no
+        # impressions_history_ads_seen key.
+        path = make_zip({
+            "test/ads_and_topics/ads_viewed.json": {"some_other_key": []},
+        })
+        try:
+            with zipfile.ZipFile(path) as zf:
+                assert count_items(zf, "*/test/ads_and_topics/ads_viewed.json",
+                                   "impressions_history_ads_seen") == 0
+        finally:
+            os.unlink(path)
+
+    def test_missing_key_in_list_form(self):
+        # Same file shape but represented as a list of one dict.
+        path = make_zip({
+            "test/ads_and_topics/ads_viewed.json": [{"some_other_key": []}],
+        })
+        try:
+            with zipfile.ZipFile(path) as zf:
+                assert count_items(zf, "*/test/ads_and_topics/ads_viewed.json",
+                                   "impressions_history_ads_seen") == 0
+        finally:
+            os.unlink(path)
+
+    def test_partial_missing_across_files(self):
+        # One file has the key, one doesn't — the missing one must not poison the count.
+        path = make_zip({
+            "test/ads_and_topics/ads_viewed_1.json":
+                {"impressions_history_ads_seen": [1, 2, 3]},
+            "test/ads_and_topics/ads_viewed_2.json":
+                {"some_other_key": []},
+        })
+        try:
+            with zipfile.ZipFile(path) as zf:
+                assert count_items(zf, "*/ads_and_topics/ads_viewed_*.json",
+                                   "impressions_history_ads_seen") == 3
+        finally:
+            os.unlink(path)
+
+
+# ---------------------------------------------------------------------------
+# get_donating_user
+# ---------------------------------------------------------------------------
+
+class TestGetDonatingUser:
+    """get_donating_user must not raise on malformed participants arrays."""
+
+    def test_missing_participants_key(self):
+        assert get_donating_user({"messages": []}) is None
+
+    def test_empty_participants_list(self):
+        assert get_donating_user({"participants": [], "messages": []}) is None
+
+    def test_participant_missing_name(self):
+        assert get_donating_user({
+            "participants": [{"id": 1}],
+            "messages": [],
+        }) is None
+
+
+# ---------------------------------------------------------------------------
+# get_string_map_timestamps
+# ---------------------------------------------------------------------------
+
+class TestGetStringMapTimestampsDefensive:
+    """Malformed string_map_data items should be skipped, not crash."""
+
+    def test_item_missing_string_map_data(self):
+        data = [{"not_what_we_expect": True}]
+        path = make_zip({"test/comments/post_comments_1.json": data})
+        try:
+            with zipfile.ZipFile(path) as zf:
+                result = list(get_string_map_timestamps(
+                    zf, "*/comments/post_comments_*.json"))
+            assert result == []
+        finally:
+            os.unlink(path)
+
+    def test_item_missing_time_subkey(self):
+        data = [{"string_map_data": {"Comment": {"value": "hi"}}}]
+        path = make_zip({"test/comments/post_comments_1.json": data})
+        try:
+            with zipfile.ZipFile(path) as zf:
+                result = list(get_string_map_timestamps(
+                    zf, "*/comments/post_comments_*.json"))
+            assert result == []
+        finally:
+            os.unlink(path)
+
+    def test_mixed_valid_and_malformed(self):
+        data = [
+            {"string_map_data": {"Time": {"timestamp": 1640995200}}},
+            {"not_what_we_expect": True},
+            {"string_map_data": {"Time": {"timestamp": 1641081600}}},
+        ]
+        path = make_zip({"test/comments/post_comments_1.json": data})
+        try:
+            with zipfile.ZipFile(path) as zf:
+                result = list(get_string_map_timestamps(
+                    zf, "*/comments/post_comments_*.json"))
+            assert len(result) == 2
+        finally:
+            os.unlink(path)
+
+    def test_missing_nested_key_with_key_param(self):
+        # When the top-level key named by `key` is missing, nothing is yielded.
+        data = {"wrong_nested_key": []}
+        path = make_zip({"test/comments/post_comments_1.json": data})
+        try:
+            with zipfile.ZipFile(path) as zf:
+                result = list(get_string_map_timestamps(
+                    zf, "*/comments/post_comments_*.json",
+                    key="expected_key"))
+            assert result == []
+        finally:
+            os.unlink(path)
+
+
+# ---------------------------------------------------------------------------
+# get_string_list_timestamps
+# ---------------------------------------------------------------------------
+
+class TestGetStringListTimestampsDefensive:
+    """Malformed string_list_data items should be skipped."""
+
+    def test_item_missing_string_list_data(self):
+        data = {"likes_media_likes": [{"unrelated": "field"}]}
+        path = make_zip({"test/likes/liked_posts.json": data})
+        try:
+            with zipfile.ZipFile(path) as zf:
+                result = list(get_string_list_timestamps(
+                    zf, "*/likes/liked_posts.json", "likes_media_likes"))
+            assert result == []
+        finally:
+            os.unlink(path)
+
+    def test_item_with_empty_string_list_data(self):
+        # IndexError hazard: item["string_list_data"][0]
+        data = {"likes_media_likes": [{"string_list_data": []}]}
+        path = make_zip({"test/likes/liked_posts.json": data})
+        try:
+            with zipfile.ZipFile(path) as zf:
+                result = list(get_string_list_timestamps(
+                    zf, "*/likes/liked_posts.json", "likes_media_likes"))
+            assert result == []
+        finally:
+            os.unlink(path)
+
+    def test_item_missing_timestamp_in_string_list_entry(self):
+        data = {"likes_media_likes": [
+            {"string_list_data": [{"value": "user1"}]}
+        ]}
+        path = make_zip({"test/likes/liked_posts.json": data})
+        try:
+            with zipfile.ZipFile(path) as zf:
+                result = list(get_string_list_timestamps(
+                    zf, "*/likes/liked_posts.json", "likes_media_likes"))
+            assert result == []
+        finally:
+            os.unlink(path)
+
+    def test_missing_top_level_key(self):
+        data = {"wrong_key": []}
+        path = make_zip({"test/likes/liked_posts.json": data})
+        try:
+            with zipfile.ZipFile(path) as zf:
+                result = list(get_string_list_timestamps(
+                    zf, "*/likes/liked_posts.json", "likes_media_likes"))
+            assert result == []
+        finally:
+            os.unlink(path)
+
+
+# ---------------------------------------------------------------------------
+# flatten_media
+# ---------------------------------------------------------------------------
+
+class TestFlattenMediaDefensive:
+    def test_list_item_missing_media_key(self):
+        result = list(flatten_media([{"not_media": []}]))
+        assert result == []
+
+    def test_list_mixed_valid_and_missing(self):
+        result = list(flatten_media([
+            {"media": [{"creation_timestamp": 1640995200}]},
+            {"not_media": []},
+            {"media": [{"creation_timestamp": 1641081600}]},
+        ]))
+        assert len(result) == 2
+
+
+# ---------------------------------------------------------------------------
+# get_creation_timestamps
+# ---------------------------------------------------------------------------
+
+class TestGetCreationTimestampsDefensive:
+    def test_item_missing_creation_timestamp(self):
+        items = [
+            {"creation_timestamp": 1640995200},
+            {"title": "no timestamp here"},
+        ]
+        result = list(get_creation_timestamps(items))
+        assert len(result) == 1
+
+
+# ---------------------------------------------------------------------------
+# get_content_posts_timestamps — new format
+# ---------------------------------------------------------------------------
+
+class TestGetContentPostsTimestampsDefensive:
+    def test_new_format_post_missing_media(self):
+        data = [
+            {"media": [{"creation_timestamp": 1640995200}]},
+            {"not_media": []},
+        ]
+        path = make_zip({
+            "your_instagram_activity/media/posts_1.json": data,
+        })
+        try:
+            with zipfile.ZipFile(path) as zf:
+                result = list(get_content_posts_timestamps(zf))
+            assert len(result) == 1
+        finally:
+            os.unlink(path)
+
+
+# ---------------------------------------------------------------------------
+# stories_timestamps
+# ---------------------------------------------------------------------------
+
+class TestStoriesTimestampsDefensive:
+    def test_stories_missing_ig_stories_key_old_format(self):
+        path = make_zip({"test/content/stories.json": {"different_key": []}})
+        try:
+            with zipfile.ZipFile(path) as zf:
+                result = list(stories_timestamps(zf))
+            assert result == []
+        finally:
+            os.unlink(path)
+
+    def test_stories_missing_ig_stories_key_new_format(self):
+        path = make_zip({
+            "your_instagram_activity/media/stories.json":
+                {"different_key": []},
+        })
+        try:
+            with zipfile.ZipFile(path) as zf:
+                result = list(stories_timestamps(zf))
+            assert result == []
+        finally:
+            os.unlink(path)
+
+    def test_story_item_missing_creation_timestamp(self):
+        path = make_zip({
+            "test/content/stories.json": {"ig_stories": [
+                {"creation_timestamp": 1640995200},
+                {"title": "no timestamp"},
+            ]},
+        })
+        try:
+            with zipfile.ZipFile(path) as zf:
+                result = list(stories_timestamps(zf))
+            assert len(result) == 1
+        finally:
+            os.unlink(path)
+
+
+# ---------------------------------------------------------------------------
+# count_messages (already has try/except, verify it still tolerates oddness)
+# ---------------------------------------------------------------------------
+
+class TestCountMessagesDefensive:
+    def test_conversation_missing_participants(self):
+        path = make_zip({
+            "test/messages/inbox/chat/message_1.json":
+                {"messages": [{"sender_name": "u1"}]},
+        })
+        try:
+            with zipfile.ZipFile(path) as zf:
+                counts = count_messages(zf)
+            assert counts == {"sent": 0, "received": 0}
+        finally:
+            os.unlink(path)
+
+    def test_conversation_missing_messages(self):
+        path = make_zip({
+            "test/messages/inbox/chat/message_1.json":
+                {"participants": [{"name": "u1"}]},
+        })
+        try:
+            with zipfile.ZipFile(path) as zf:
+                counts = count_messages(zf)
+            assert counts == {"sent": 0, "received": 0}
+        finally:
+            os.unlink(path)
+
+
+# ---------------------------------------------------------------------------
+# get_video_posts_timestamps — integration: post with no media list
+# ---------------------------------------------------------------------------
+
+class TestGetVideoPostsTimestampsDefensive:
+    def test_igtv_missing_key(self):
+        path = make_zip({"test/content/igtv_videos.json": {"wrong_key": []}})
+        try:
+            with zipfile.ZipFile(path) as zf:
+                result = list(get_video_posts_timestamps(zf))
+            assert result == []
+        finally:
+            os.unlink(path)
+
+    def test_reels_missing_key(self):
+        path = make_zip({"test/content/reels.json": {"wrong_key": []}})
+        try:
+            with zipfile.ZipFile(path) as zf:
+                result = list(get_video_posts_timestamps(zf))
+            assert result == []
+        finally:
+            os.unlink(path)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/packages/python/tests/test_newer_format.py
+++ b/packages/python/tests/test_newer_format.py
@@ -1,10 +1,10 @@
-"""End-to-end tests that extract_data handles both export shapes.
+"""End-to-end tests: extract_data handles both export shapes.
 
 Legacy shape: top-level dict with a well-known key (likes_media_likes,
 impressions_history_*, ig_stories, ig_igtv_media, ig_reels_media,
-relationships_following) where each event wraps the timestamp under
-`string_list_data[0].timestamp`, `string_map_data.Time.timestamp`,
-or `media[].creation_timestamp`.
+relationships_following, media[...]) where each event wraps the
+timestamp under `string_list_data[0].timestamp`,
+`string_map_data.Time.timestamp`, or `media[].creation_timestamp`.
 
 Newer shape: top-level list where each event has `timestamp` or
 `creation_timestamp` directly at the root.
@@ -42,9 +42,20 @@ def _summary_row(tables, description):
 
 
 class TestNewerFormatExtraction:
-    """After the shape-detection fix these must all pass."""
+    """Every data table must populate for a newer-shape zip."""
+
+    def test_video_posts_populated(self):
+        # 6 posts + 4 stories + 2 igtv + 3 reels = 15 events; grouped
+        # per hour they collapse into a handful of rows but must be > 0.
+        path = make_newer_format_zip()
+        try:
+            tables = _run(path)
+            assert len(tables["instagram_video_posts"]) > 0
+        finally:
+            os.unlink(path)
 
     def test_comments_and_likes_populated(self):
+        # 9 comments + 7 liked posts + 4 liked comments = 20 events.
         path = make_newer_format_zip()
         try:
             tables = _run(path)
@@ -60,20 +71,26 @@ class TestNewerFormatExtraction:
         finally:
             os.unlink(path)
 
-    def test_summary_ads_viewed_counted(self):
-        path = make_newer_format_zip()
-        try:
-            tables = _run(path)
-            assert _summary_row(tables, "Ads viewed") == 2  # make_newer uses 2
-        finally:
-            os.unlink(path)
-
     def test_dm_activity_still_works(self):
         path = make_newer_format_zip()
         try:
             tables = _run(path)
-            # Newer fixture: 5 + 3 = 8 messages
             assert len(tables["instagram_direct_message_activity"]) == 8
+        finally:
+            os.unlink(path)
+
+    def test_summary_counts_reflect_newer_shape(self):
+        path = make_newer_format_zip()
+        try:
+            tables = _run(path)
+            # count_posts sums posts + igtv + reels (all video content).
+            # Fixture: 6 posts + 2 igtv + 3 reels = 11.
+            assert _summary_row(tables, "Posts published") == 11
+            assert _summary_row(tables, "Stories published") == 4
+            assert _summary_row(tables, "Comments published") == 9
+            assert _summary_row(tables, "Ads viewed") == 2
+            assert _summary_row(tables, "Followers") == 4
+            assert _summary_row(tables, "Following") == 3
         finally:
             os.unlink(path)
 
@@ -86,7 +103,6 @@ class TestLegacyFormatNoRegression:
         try:
             tables = _run(path)
             # make_legacy_format_zip produces these exact counts today.
-            # Any drift means we broke backwards compatibility.
             assert len(tables["instagram_comments_and_likes"]) == 7
             assert len(tables["instagram_viewed"]) == 15
             assert len(tables["instagram_direct_message_activity"]) == 5

--- a/packages/python/tests/test_newer_format.py
+++ b/packages/python/tests/test_newer_format.py
@@ -1,0 +1,104 @@
+"""End-to-end tests that extract_data handles both export shapes.
+
+Legacy shape: top-level dict with a well-known key (likes_media_likes,
+impressions_history_*, ig_stories, ig_igtv_media, ig_reels_media,
+relationships_following) where each event wraps the timestamp under
+`string_list_data[0].timestamp`, `string_map_data.Time.timestamp`,
+or `media[].creation_timestamp`.
+
+Newer shape: top-level list where each event has `timestamp` or
+`creation_timestamp` directly at the root.
+
+Issue 9808995489 — Support newer Instagram export format.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "port"))
+sys.path.insert(0, os.path.dirname(__file__))
+
+from port.api.commands import FlushLogs  # noqa: E402
+from script import extract_data  # noqa: E402
+from fixtures import (  # noqa: E402
+    make_legacy_format_zip,
+    make_newer_format_zip,
+)
+
+
+def _run(zip_path):
+    result = None
+    for item in extract_data(zip_path, "en"):
+        if item is not FlushLogs:
+            result = item
+    return {er.id: er.data_frame for er in result}
+
+
+def _summary_row(tables, description):
+    df = tables["instagram_summary"]
+    matches = df[df["Description"] == description]
+    assert not matches.empty, f"no summary row {description!r}"
+    return int(matches.iloc[0]["Number"])
+
+
+class TestNewerFormatExtraction:
+    """After the shape-detection fix these must all pass."""
+
+    def test_comments_and_likes_populated(self):
+        path = make_newer_format_zip()
+        try:
+            tables = _run(path)
+            assert len(tables["instagram_comments_and_likes"]) > 0
+        finally:
+            os.unlink(path)
+
+    def test_viewed_populated(self):
+        path = make_newer_format_zip()
+        try:
+            tables = _run(path)
+            assert len(tables["instagram_viewed"]) > 0
+        finally:
+            os.unlink(path)
+
+    def test_summary_ads_viewed_counted(self):
+        path = make_newer_format_zip()
+        try:
+            tables = _run(path)
+            assert _summary_row(tables, "Ads viewed") == 2  # make_newer uses 2
+        finally:
+            os.unlink(path)
+
+    def test_dm_activity_still_works(self):
+        path = make_newer_format_zip()
+        try:
+            tables = _run(path)
+            # Newer fixture: 5 + 3 = 8 messages
+            assert len(tables["instagram_direct_message_activity"]) == 8
+        finally:
+            os.unlink(path)
+
+
+class TestLegacyFormatNoRegression:
+    """Legacy extraction must continue to behave as before the shape fix."""
+
+    def test_all_tables_populated(self):
+        path = make_legacy_format_zip()
+        try:
+            tables = _run(path)
+            # make_legacy_format_zip produces these exact counts today.
+            # Any drift means we broke backwards compatibility.
+            assert len(tables["instagram_comments_and_likes"]) == 7
+            assert len(tables["instagram_viewed"]) == 15
+            assert len(tables["instagram_direct_message_activity"]) == 5
+        finally:
+            os.unlink(path)
+
+    def test_summary_counts_preserved(self):
+        path = make_legacy_format_zip()
+        try:
+            tables = _run(path)
+            assert _summary_row(tables, "Ads viewed") == 2
+            assert _summary_row(tables, "Followers") == 4
+            assert _summary_row(tables, "Following") == 3
+        finally:
+            os.unlink(path)

--- a/tests/generate_random_fixtures.sh
+++ b/tests/generate_random_fixtures.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Regenerate both random Instagram fixture folders (+ zips) for manual testing.
+#
+# Output: tests/random_instagram_fixture{,_legacy}/ and .zip
+# Both gitignored — treat them as derived artifacts.
+#
+# Deterministic seed 42; pass --seed <n> to override.
+#
+# Usage:
+#   ./tests/generate_random_fixtures.sh                 # default: realistic
+#   ./tests/generate_random_fixtures.sh --scale small
+#   ./tests/generate_random_fixtures.sh --scale large
+
+set -euo pipefail
+
+SCALE="realistic"
+SEED="42"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --scale) SCALE="$2"; shift 2 ;;
+        --seed)  SEED="$2";  shift 2 ;;
+        -h|--help)
+            sed -n '2,14p' "$0"; exit 0 ;;
+        *) echo "unknown arg: $1" >&2; exit 2 ;;
+    esac
+done
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+PYDIR="$REPO_ROOT/packages/python"
+OUT_NEWER="$REPO_ROOT/tests/random_instagram_fixture"
+OUT_LEGACY="$REPO_ROOT/tests/random_instagram_fixture_legacy"
+
+rm -rf "$OUT_NEWER" "$OUT_LEGACY"
+
+cd "$PYDIR"
+poetry run python -m tests.fixtures "$OUT_NEWER"  --format newer  --scale "$SCALE" --seed "$SEED" --zip
+poetry run python -m tests.fixtures "$OUT_LEGACY" --format legacy --scale "$SCALE" --seed "$SEED" --zip
+
+echo
+echo "Done. Artifacts:"
+ls -la "$OUT_NEWER.zip" "$OUT_LEGACY.zip"


### PR DESCRIPTION
## Summary

Merges milestone/1.1 (hotfix error monitoring) into master. Rolls up 17 commits across 6 merged PRs:

- #7 — Surface worker errors and runCycle telemetry to AppSignal (pyodide exceptions no longer silently dropped)
- #9 — Defensive key access throughout the extractor (malformed records skipped, not crashing)
- PR on `get_in` list-safety follow-up (direct commit)
- Fixture scaffolding: `fixtures.py` + `generate_random_fixtures.sh` + `--zip` flag
- #10 — Support both legacy and newer Instagram export shapes (likes / ads / viewed)
- #11 — Extend shape detection to all data points (posts / stories / igtv / reels / comments)
- #12 — Align fixture writers so both shapes produce identical counts
- Release workflow fix: `target_commitish: github.sha`

## What ships

- Every Instagram participant — old or new Instagram export shape — gets a full donation with all 5 tables populated.
- Any worker-side Python exception now surfaces in AppSignal with stack + runCycle context.
- Fixture generators for both shapes available for manual testing (`./tests/generate_random_fixtures.sh`).

Linked to Basecamp milestone: Cambridge Instagram - Milestone 1.1 - Hotfix error monitoring.

## Test plan

- [x] 55 Python tests pass across the branch
- [x] Pre-commit Playwright e2e passes on every intermediate PR
- [x] Both random fixtures produce identical row counts through extract_data

🤖 Generated with [Claude Code](https://claude.com/claude-code)