### PR TITLE
Support both legacy and newer Instagram export shapes

### DIFF
--- a/packages/python/port/script.py
+++ b/packages/python/port/script.py
@@ -247,22 +247,62 @@ def map_to_timeslot(series):
     return series.map(lambda hour: f"{hour}-{hour+1}")
 
 
+def _resolve_event_list(data, key=None):
+    """Return the event list from a source file, tolerating both shapes.
+
+    - Newer shape: top-level list → return it
+    - Legacy shape: dict with the `key` well-known name → return dict[key]
+    - Legacy edge: dict representing a single event → return [data]
+    Returns [] when nothing matches.
+    """
+    if isinstance(data, list):
+        return data
+    if isinstance(data, dict):
+        if key is not None:
+            value = data.get(key)
+            if isinstance(value, list):
+                return value
+            if isinstance(value, dict):
+                return [value]
+            return []
+        return [data]
+    return []
+
+
+def extract_event_timestamp(item):
+    """Return a parsed timestamp from an event dict across known shapes.
+
+    Tries, in order:
+    1. newer flat shape: item["timestamp"]
+    2. legacy string_list wrapper: item["string_list_data"][0]["timestamp"]
+    3. legacy string_map wrapper: item["string_map_data"]["Time"]["timestamp"]
+    """
+    if not isinstance(item, dict):
+        return None
+    ts = get_timestamp(item, "timestamp")
+    if ts is not None:
+        return ts
+    entries = get_in(item, "string_list_data")
+    if isinstance(entries, list) and entries:
+        ts = get_timestamp(entries[0], "timestamp")
+        if ts is not None:
+            return ts
+    return get_timestamp(item, "string_map_data", "Time", "timestamp")
+
+
 def count_items(zipfile, pattern, key=None):
     count = 0
     for data in glob_json(zipfile, pattern):
-        # Some files have dictionary, others a list of dictionaries. Normalize
-        # this to always a list so the rest of the code works regardless.
-        if isinstance(data, dict):
-            data = [data]
-        for item in data:
-            if not isinstance(item, (dict, list, str)):
-                continue
-            if key is None:
-                count += len(item)
-            else:
-                value = item.get(key) if isinstance(item, dict) else None
-                if value is not None:
-                    count += len(value)
+        if key is None:
+            # Sum len of each record (used by followers/following counters)
+            if isinstance(data, dict):
+                data = [data]
+            for item in data:
+                if isinstance(item, (dict, list, str)):
+                    count += len(item)
+        else:
+            # Event-list counting — works for both shapes
+            count += len(_resolve_event_list(data, key))
     return count
 
 
@@ -556,11 +596,7 @@ def get_content_posts_timestamps(zipfile):
 
 def get_media_timestamps(zipfile, pattern, key):
     for data in glob_json(zipfile, pattern):
-        if not isinstance(data, dict):
-            continue
-        items = data.get(key)
-        if items is None:
-            continue
+        items = _resolve_event_list(data, key)
         yield from get_media_creation_timestamps(items)
 
 
@@ -580,12 +616,10 @@ def stories_timestamps(zipfile):
     )
     for pattern in patterns:
         for data in glob_json(zipfile, pattern):
-            if not isinstance(data, dict):
-                continue
-            stories = data.get("ig_stories")
-            if not isinstance(stories, list):
-                continue
-            yield from get_creation_timestamps(stories)
+            # Legacy: {"ig_stories": [...]}.  Newer (hypothetical): top-level list.
+            yield from get_creation_timestamps(
+                _resolve_event_list(data, "ig_stories")
+            )
             
 
 def df_from_timestamp_columns(a, b):
@@ -750,34 +784,19 @@ def get_post_comments_timestamps(zipfile):
 
 
 def get_string_map_timestamps(zipfile, pattern, key=None):
+    # Shape-agnostic: tries flat + legacy nested shapes per event.
     for data in glob_json(zipfile, pattern):
-        if key is not None:
-            data = get_in(data, key)
-            if data is None:
-                continue
-        items = data if isinstance(data, list) else [data]
-        for item in items:
-            ts = get_timestamp(item, "string_map_data", "Time", "timestamp")
+        for item in _resolve_event_list(data, key):
+            ts = extract_event_timestamp(item)
             if ts is not None:
                 yield ts
-
 
 
 def get_string_list_timestamps(zipfile, pattern, key=None):
-    for data in glob_json(zipfile, pattern):
-        if key is not None:
-            data = get_in(data, key)
-            if data is None:
-                continue
-        if not isinstance(data, list):
-            continue
-        for item in data:
-            entries = get_in(item, "string_list_data") or []
-            if not entries:
-                continue
-            ts = get_timestamp(entries[0], "timestamp")
-            if ts is not None:
-                yield ts
+    # Shape-agnostic — same logic as get_string_map_timestamps. The
+    # two historically distinguished which nested wrapper to expect;
+    # extract_event_timestamp now tries both plus the newer flat shape.
+    yield from get_string_map_timestamps(zipfile, pattern, key)
 
 
 def get_likes_timestamps(zipfile):

--- a/packages/python/tests/test_defensive_key_access.py
+++ b/packages/python/tests/test_defensive_key_access.py
@@ -229,10 +229,12 @@ class TestGetStringListTimestampsDefensive:
         finally:
             os.unlink(path)
 
-    def test_top_level_is_list_when_key_expected(self):
-        # Reproduces a production crash: file's top level is a list, but
-        # caller passed a key expecting a dict. get_in must not AttributeError.
-        data = [{"string_list_data": [{"timestamp": 1640995200}]}]
+    def test_top_level_list_with_no_extractable_timestamp(self):
+        # Originally guarded a get_in/list AttributeError. With shape
+        # detection a top-level list is now a valid (newer) shape, so
+        # extraction proceeds. The defensive case becomes: list data
+        # whose entries expose nothing recognizable as a timestamp.
+        data = [{"unrelated": True}, "not even a dict"]
         path = make_zip({"test/likes/liked_posts.json": data})
         try:
             with zipfile.ZipFile(path) as zf:

--- a/packages/python/tests/test_newer_format.py
+++ b/packages/python/tests/test_newer_format.py
@@ -1,0 +1,104 @@
+"""End-to-end tests that extract_data handles both export shapes.
+
+Legacy shape: top-level dict with a well-known key (likes_media_likes,
+impressions_history_*, ig_stories, ig_igtv_media, ig_reels_media,
+relationships_following) where each event wraps the timestamp under
+`string_list_data[0].timestamp`, `string_map_data.Time.timestamp`,
+or `media[].creation_timestamp`.
+
+Newer shape: top-level list where each event has `timestamp` or
+`creation_timestamp` directly at the root.
+
+Issue 9808995489 — Support newer Instagram export format.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "port"))
+sys.path.insert(0, os.path.dirname(__file__))
+
+from port.api.commands import FlushLogs  # noqa: E402
+from script import extract_data  # noqa: E402
+from fixtures import (  # noqa: E402
+    make_legacy_format_zip,
+    make_newer_format_zip,
+)
+
+
+def _run(zip_path):
+    result = None
+    for item in extract_data(zip_path, "en"):
+        if item is not FlushLogs:
+            result = item
+    return {er.id: er.data_frame for er in result}
+
+
+def _summary_row(tables, description):
+    df = tables["instagram_summary"]
+    matches = df[df["Description"] == description]
+    assert not matches.empty, f"no summary row {description!r}"
+    return int(matches.iloc[0]["Number"])
+
+
+class TestNewerFormatExtraction:
+    """After the shape-detection fix these must all pass."""
+
+    def test_comments_and_likes_populated(self):
+        path = make_newer_format_zip()
+        try:
+            tables = _run(path)
+            assert len(tables["instagram_comments_and_likes"]) > 0
+        finally:
+            os.unlink(path)
+
+    def test_viewed_populated(self):
+        path = make_newer_format_zip()
+        try:
+            tables = _run(path)
+            assert len(tables["instagram_viewed"]) > 0
+        finally:
+            os.unlink(path)
+
+    def test_summary_ads_viewed_counted(self):
+        path = make_newer_format_zip()
+        try:
+            tables = _run(path)
+            assert _summary_row(tables, "Ads viewed") == 2  # make_newer uses 2
+        finally:
+            os.unlink(path)
+
+    def test_dm_activity_still_works(self):
+        path = make_newer_format_zip()
+        try:
+            tables = _run(path)
+            # Newer fixture: 5 + 3 = 8 messages
+            assert len(tables["instagram_direct_message_activity"]) == 8
+        finally:
+            os.unlink(path)
+
+
+class TestLegacyFormatNoRegression:
+    """Legacy extraction must continue to behave as before the shape fix."""
+
+    def test_all_tables_populated(self):
+        path = make_legacy_format_zip()
+        try:
+            tables = _run(path)
+            # make_legacy_format_zip produces these exact counts today.
+            # Any drift means we broke backwards compatibility.
+            assert len(tables["instagram_comments_and_likes"]) == 7
+            assert len(tables["instagram_viewed"]) == 15
+            assert len(tables["instagram_direct_message_activity"]) == 5
+        finally:
+            os.unlink(path)
+
+    def test_summary_counts_preserved(self):
+        path = make_legacy_format_zip()
+        try:
+            tables = _run(path)
+            assert _summary_row(tables, "Ads viewed") == 2
+            assert _summary_row(tables, "Followers") == 4
+            assert _summary_row(tables, "Following") == 3
+        finally:
+            os.unlink(path)


### PR DESCRIPTION
## Summary

One parser, two shapes. Teaches the extraction helpers to accept both the legacy shape (top-level dict keyed by well-known names like `likes_media_likes`, with timestamps nested under `string_list_data[0].timestamp` / `string_map_data.Time.timestamp`) and the newer shape Instagram now ships (top-level list, `timestamp` at the event root).

No cohort switching, no second package — shape detection happens per file at read time based on top-level type.

## Verification

Run against the two deterministic fixtures (`seed=42`, `scale=realistic`):

| Table | Newer (before) | Newer (after) | Legacy (before) | Legacy (after) |
|---|---:|---:|---:|---:|
| `instagram_summary` | 8 | 8 | 8 | 8 |
| `instagram_video_posts` | 0 | 0* | 35 | 35 |
| `instagram_comments_and_likes` | 0 | **40** | 119 | 119 |
| `instagram_viewed` | 0 | **934** | 936 | 936 |
| `instagram_direct_message_activity` | 571 | 571 | 545 | 545 |
| summary "Ads viewed" | 0 | **40** | 40 | 40 |

\* Newer fixture has no posts/stories — the newer shape for those files hasn't been observed in a real zip yet, so those paths still only recognize legacy shape. Extraction is ready to absorb them once we have an example.

## Test plan

- [x] New `test_newer_format.py`: end-to-end extraction tests for both fixtures, asserting populated vs regression-free counts
- [x] `test_defensive_key_access.py`: one test reinterpreted (top-level list is no longer a shape error); all 25 still green
- [x] Full pytest suite: 54 passed
- [x] Pre-commit Playwright e2e: passing
- [x] Manual: both random fixture zips produce expected output through extract_data

Refs scriptdev issue 9808995489. Part of milestone 1.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)