### PR TITLE
Extend shape detection to all data points

### DIFF
--- a/packages/python/port/script.py
+++ b/packages/python/port/script.py
@@ -274,14 +274,16 @@ def extract_event_timestamp(item):
 
     Tries, in order:
     1. newer flat shape: item["timestamp"]
-    2. legacy string_list wrapper: item["string_list_data"][0]["timestamp"]
-    3. legacy string_map wrapper: item["string_map_data"]["Time"]["timestamp"]
+    2. newer flat shape (content): item["creation_timestamp"]
+    3. legacy string_list wrapper: item["string_list_data"][0]["timestamp"]
+    4. legacy string_map wrapper: item["string_map_data"]["Time"]["timestamp"]
     """
     if not isinstance(item, dict):
         return None
-    ts = get_timestamp(item, "timestamp")
-    if ts is not None:
-        return ts
+    for flat_key in ("timestamp", "creation_timestamp"):
+        ts = get_timestamp(item, flat_key)
+        if ts is not None:
+            return ts
     entries = get_in(item, "string_list_data")
     if isinstance(entries, list) and entries:
         ts = get_timestamp(entries[0], "timestamp")
@@ -293,16 +295,7 @@ def extract_event_timestamp(item):
 def count_items(zipfile, pattern, key=None):
     count = 0
     for data in glob_json(zipfile, pattern):
-        if key is None:
-            # Sum len of each record (used by followers/following counters)
-            if isinstance(data, dict):
-                data = [data]
-            for item in data:
-                if isinstance(item, (dict, list, str)):
-                    count += len(item)
-        else:
-            # Event-list counting — works for both shapes
-            count += len(_resolve_event_list(data, key))
+        count += len(_resolve_event_list(data, key))
     return count
 
 
@@ -559,15 +552,22 @@ def extract_direct_message_activity(zipfile):
 def flatten_media(media):
     if isinstance(media, list):
         for item in media:
-            if isinstance(item, dict) and isinstance(item.get("media"), list):
-                yield from item["media"]
+            if not isinstance(item, dict):
+                continue
+            nested = item.get("media")
+            if isinstance(nested, list):
+                # Legacy shape: media entries live in a nested "media" list.
+                yield from nested
+            else:
+                # Newer flat shape: the post itself carries the timestamp.
+                yield item
     else:
         yield media
 
 
 def get_creation_timestamps(items):
     for item in items:
-        ts = get_timestamp(item, "creation_timestamp")
+        ts = extract_event_timestamp(item)
         if ts is not None:
             yield ts
 
@@ -577,27 +577,24 @@ def get_media_creation_timestamps(items):
 
 
 def get_content_posts_timestamps(zipfile):
-    # Old format
-    for data in glob_json(zipfile, "*/content/posts_*.json"):
-
-        yield from get_media_creation_timestamps(data)
-    # New format: yield the first media item's timestamp per post
-    for data in glob_json(zipfile, "your_instagram_activity/media/posts_*.json"):
-        if not isinstance(data, list):
-            continue
-        for post in data:
-            media_list = get_in(post, "media") or []
-            for media in media_list:
-                ts = get_timestamp(media, "creation_timestamp")
-                if ts is not None:
-                    yield ts
-                    break
+    # Both legacy `*/content/posts_*.json` and newer
+    # `your_instagram_activity/media/posts_*.json` yield via the same
+    # flatten_media + get_creation_timestamps pipeline, which now handles:
+    #   - legacy post entries wrapping media[].creation_timestamp
+    #   - newer flat post entries with creation_timestamp/timestamp at root
+    for pattern in ("*/content/posts_*.json",
+                    "your_instagram_activity/media/posts_*.json"):
+        for data in glob_json(zipfile, pattern):
+            yield from get_media_creation_timestamps(data)
 
 
-def get_media_timestamps(zipfile, pattern, key):
-    for data in glob_json(zipfile, pattern):
-        items = _resolve_event_list(data, key)
-        yield from get_media_creation_timestamps(items)
+def get_media_timestamps(zipfile, patterns, key):
+    if isinstance(patterns, str):
+        patterns = (patterns,)
+    for pattern in patterns:
+        for data in glob_json(zipfile, pattern):
+            items = _resolve_event_list(data, key)
+            yield from get_media_creation_timestamps(items)
 
 
 def df_from_timestamps(timestamps, column):
@@ -652,8 +649,18 @@ def df_from_timestamp_columns(a, b):
 def get_video_posts_timestamps(zipfile):
     return itertools.chain(
         get_content_posts_timestamps(zipfile),
-        get_media_timestamps(zipfile, "*/content/igtv_videos.json", "ig_igtv_media"),
-        get_media_timestamps(zipfile, "*/content/reels.json", "ig_reels_media"),
+        get_media_timestamps(
+            zipfile,
+            ("*/content/igtv_videos.json",
+             "your_instagram_activity/media/igtv_videos.json"),
+            "ig_igtv_media",
+        ),
+        get_media_timestamps(
+            zipfile,
+            ("*/content/reels.json",
+             "your_instagram_activity/media/reels.json"),
+            "ig_reels_media",
+        ),
     )
 
 

--- a/packages/python/tests/fixtures.py
+++ b/packages/python/tests/fixtures.py
@@ -100,18 +100,24 @@ def _newer_flat_event(ts):
     return {"timestamp": ts, "media": [], "label_values": []}
 
 
+def _newer_creation_event(ts):
+    """A single content entry in the newer flat shape."""
+    return {"creation_timestamp": ts}
+
+
 def make_newer_format_zip():
     """Create a zip that mirrors the newer Instagram export shape.
 
-    Returns the absolute path to the zip. Callers must unlink it.
+    All source files the extractor reads are represented with their
+    newer shape (top-level list, flat `timestamp` / `creation_timestamp`).
 
-    Contents (all counts are small but non-trivial so tests can assert):
-      - 2 message threads (5 + 3 messages = 8 total messages)
-      - 10 videos_watched entries
-      - 5 posts_viewed entries
-      - 2 ads_viewed entries
-      - 7 liked_posts entries
-      - 3 following + 4 followers (summary counts)
+    Contents:
+      - 2 message threads (5 + 3 = 8 messages)
+      - ads_and_topics: 10 videos_watched, 5 posts_viewed, 2 ads_viewed
+      - likes: 7 liked_posts, 4 liked_comments
+      - content: 6 posts, 4 stories, 2 igtv_videos, 3 reels
+      - 9 post_comments
+      - 3 following + 4 followers
     """
     files = {
         "your_instagram_activity/messages/inbox/conv_a_1111/message_1.json":
@@ -121,6 +127,7 @@ def make_newer_format_zip():
             _newer_message_file(["Bob Test", "Donor User"], message_count=3,
                                 start_offset_hours=10),
 
+        # ads_and_topics — top-level list + flat `timestamp`
         "ads_information/ads_and_topics/videos_watched.json":
             [_newer_flat_event(t) for t in _timestamp_list(10, 100)],
         "ads_information/ads_and_topics/posts_viewed.json":
@@ -128,13 +135,28 @@ def make_newer_format_zip():
         "ads_information/ads_and_topics/ads_viewed.json":
             [_newer_flat_event(t) for t in _timestamp_list(2, 300)],
 
+        # likes — top-level list + flat `timestamp`
         "your_instagram_activity/likes/liked_posts.json":
             [_newer_flat_event(t) for t in _timestamp_list(7, 400)],
+        "your_instagram_activity/likes/liked_comments.json":
+            [_newer_flat_event(t) for t in _timestamp_list(4, 500)],
 
-        # Summary inputs — followers/following are still counted, so we
-        # need something the existing counter understands. The newer
-        # shape for these has not been observed yet; using legacy shape
-        # here until a participant zip clarifies it.
+        # content — top-level list + flat `creation_timestamp`
+        "your_instagram_activity/media/posts_1.json":
+            [_newer_creation_event(t) for t in _timestamp_list(6, 600)],
+        "your_instagram_activity/media/stories.json":
+            [_newer_creation_event(t) for t in _timestamp_list(4, 700)],
+        "your_instagram_activity/media/igtv_videos.json":
+            [_newer_creation_event(t) for t in _timestamp_list(2, 800)],
+        "your_instagram_activity/media/reels.json":
+            [_newer_creation_event(t) for t in _timestamp_list(3, 900)],
+
+        # comments — top-level list + flat `timestamp`
+        "your_instagram_activity/comments/post_comments_1.json":
+            [_newer_flat_event(t) for t in _timestamp_list(9, 1000)],
+
+        # Followers/following — newer shape not yet observed in a real
+        # export; keep the legacy shape here until we have evidence.
         "connections/followers_and_following/followers_1.json": {
             "string_list_data": [
                 {"value": f"follower_{i}"} for i in range(4)
@@ -292,7 +314,7 @@ def write_newer_format_folder(out_dir, scale="realistic", seed=None):
             },
         )
 
-    # Newer-format top-level-list files
+    # ads_and_topics — top-level list + flat `timestamp`
     for name, count in [
         ("videos_watched.json", cfg["videos"]),
         ("posts_viewed.json", cfg["posts"]),
@@ -303,9 +325,36 @@ def write_newer_format_folder(out_dir, scale="realistic", seed=None):
             [_newer_flat_event(t) for t in _random_timestamps(rng, count)],
         )
 
+    # likes — top-level list + flat `timestamp`
     _dump(
         _abspath("your_instagram_activity", "likes", "liked_posts.json"),
         [_newer_flat_event(t) for t in _random_timestamps(rng, cfg["likes"])],
+    )
+    _dump(
+        _abspath("your_instagram_activity", "likes", "liked_comments.json"),
+        [_newer_flat_event(t)
+         for t in _random_timestamps(rng, cfg["liked_comments"])],
+    )
+
+    # content (posts / stories / igtv / reels) — top-level list +
+    # flat `creation_timestamp`. Paths live under the newer
+    # `your_instagram_activity/media/...` location.
+    for name, count in [
+        ("posts_1.json", cfg["content_posts"]),
+        ("stories.json", cfg["stories"]),
+        ("igtv_videos.json", cfg["igtv"]),
+        ("reels.json", cfg["reels"]),
+    ]:
+        _dump(
+            _abspath("your_instagram_activity", "media", name),
+            [{"creation_timestamp": t}
+             for t in _random_timestamps(rng, count)],
+        )
+
+    # comments — top-level list + flat `timestamp`
+    _dump(
+        _abspath("your_instagram_activity", "comments", "post_comments_1.json"),
+        [_newer_flat_event(t) for t in _random_timestamps(rng, cfg["comments"])],
     )
 
     # Followers / following still use the legacy summary shape — the

--- a/packages/python/tests/test_defensive_key_access.py
+++ b/packages/python/tests/test_defensive_key_access.py
@@ -250,17 +250,28 @@ class TestGetStringListTimestampsDefensive:
 # ---------------------------------------------------------------------------
 
 class TestFlattenMediaDefensive:
-    def test_list_item_missing_media_key(self):
-        result = list(flatten_media([{"not_media": []}]))
-        assert result == []
+    """flatten_media supports both shapes:
 
-    def test_list_mixed_valid_and_missing(self):
+    - Legacy: each item has a "media" list → yield from that list.
+    - Newer flat: no "media" key → yield the item itself (downstream
+      extract_event_timestamp will read its root-level creation_timestamp).
+    """
+
+    def test_list_item_without_media_yielded_as_is(self):
+        # The item has no "media" key, so it's treated as a flat-shape
+        # post and yielded directly. If it has no recognizable timestamp
+        # downstream, get_creation_timestamps will skip it anyway.
+        result = list(flatten_media([{"not_media": []}]))
+        assert result == [{"not_media": []}]
+
+    def test_list_mixed_nested_and_flat(self):
         result = list(flatten_media([
             {"media": [{"creation_timestamp": 1640995200}]},
-            {"not_media": []},
+            {"creation_timestamp": 1641000000},
             {"media": [{"creation_timestamp": 1641081600}]},
         ]))
-        assert len(result) == 2
+        # Two media entries + one flat entry = 3 items yielded.
+        assert len(result) == 3
 
 
 # ---------------------------------------------------------------------------

--- a/packages/python/tests/test_newer_format.py
+++ b/packages/python/tests/test_newer_format.py
@@ -1,10 +1,10 @@
-"""End-to-end tests that extract_data handles both export shapes.
+"""End-to-end tests: extract_data handles both export shapes.
 
 Legacy shape: top-level dict with a well-known key (likes_media_likes,
 impressions_history_*, ig_stories, ig_igtv_media, ig_reels_media,
-relationships_following) where each event wraps the timestamp under
-`string_list_data[0].timestamp`, `string_map_data.Time.timestamp`,
-or `media[].creation_timestamp`.
+relationships_following, media[...]) where each event wraps the
+timestamp under `string_list_data[0].timestamp`,
+`string_map_data.Time.timestamp`, or `media[].creation_timestamp`.
 
 Newer shape: top-level list where each event has `timestamp` or
 `creation_timestamp` directly at the root.
@@ -42,9 +42,20 @@ def _summary_row(tables, description):
 
 
 class TestNewerFormatExtraction:
-    """After the shape-detection fix these must all pass."""
+    """Every data table must populate for a newer-shape zip."""
+
+    def test_video_posts_populated(self):
+        # 6 posts + 4 stories + 2 igtv + 3 reels = 15 events; grouped
+        # per hour they collapse into a handful of rows but must be > 0.
+        path = make_newer_format_zip()
+        try:
+            tables = _run(path)
+            assert len(tables["instagram_video_posts"]) > 0
+        finally:
+            os.unlink(path)
 
     def test_comments_and_likes_populated(self):
+        # 9 comments + 7 liked posts + 4 liked comments = 20 events.
         path = make_newer_format_zip()
         try:
             tables = _run(path)
@@ -60,20 +71,26 @@ class TestNewerFormatExtraction:
         finally:
             os.unlink(path)
 
-    def test_summary_ads_viewed_counted(self):
-        path = make_newer_format_zip()
-        try:
-            tables = _run(path)
-            assert _summary_row(tables, "Ads viewed") == 2  # make_newer uses 2
-        finally:
-            os.unlink(path)
-
     def test_dm_activity_still_works(self):
         path = make_newer_format_zip()
         try:
             tables = _run(path)
-            # Newer fixture: 5 + 3 = 8 messages
             assert len(tables["instagram_direct_message_activity"]) == 8
+        finally:
+            os.unlink(path)
+
+    def test_summary_counts_reflect_newer_shape(self):
+        path = make_newer_format_zip()
+        try:
+            tables = _run(path)
+            # count_posts sums posts + igtv + reels (all video content).
+            # Fixture: 6 posts + 2 igtv + 3 reels = 11.
+            assert _summary_row(tables, "Posts published") == 11
+            assert _summary_row(tables, "Stories published") == 4
+            assert _summary_row(tables, "Comments published") == 9
+            assert _summary_row(tables, "Ads viewed") == 2
+            assert _summary_row(tables, "Followers") == 4
+            assert _summary_row(tables, "Following") == 3
         finally:
             os.unlink(path)
 
@@ -86,7 +103,6 @@ class TestLegacyFormatNoRegression:
         try:
             tables = _run(path)
             # make_legacy_format_zip produces these exact counts today.
-            # Any drift means we broke backwards compatibility.
             assert len(tables["instagram_comments_and_likes"]) == 7
             assert len(tables["instagram_viewed"]) == 15
             assert len(tables["instagram_direct_message_activity"]) == 5


### PR DESCRIPTION
## Summary

Follow-up to PR #10. The earlier commit handled only the confirmed sources (likes, ads_and_topics/viewed). This extends the same shape-detection pattern to every remaining source the extractor reads — posts, stories, igtv, reels, comments, liked_comments — so a newer-shape participant zip populates all 5 tables, not just two.

## Changes

- `extract_event_timestamp` also tries `creation_timestamp` at root
- `flatten_media` yields the item itself when it has no `media` wrapper (newer flat content entry)
- `get_creation_timestamps` routes through `extract_event_timestamp`
- `get_content_posts_timestamps` uses one pipeline for both paths
- `get_media_timestamps` accepts multiple glob patterns
- `get_video_posts_timestamps` searches `your_instagram_activity/media/` for igtv/reels in addition to the legacy `*/content/` location
- `count_items` simplified: length of the resolved event list works for both no-key and keyed cases

Test fixtures: `make_newer_format_zip` and `write_newer_format_folder` now include posts/stories/igtv/reels/comments/liked_comments in the newer shape.

Two `flatten_media` defensive tests reinterpreted: a list item without `media` is no longer a shape error — it's a valid flat-shape post. Tests now assert yield-as-is.

## Extraction output

Seed=42, realistic scale:

| Table | Newer (before) | Newer (after) | Legacy |
|---|---:|---:|---:|
| `instagram_video_posts` | 0 | **49** | 50 |
| `instagram_comments_and_likes` | 40 | **119** | 119 |
| `instagram_viewed` | 934 | 934 | 936 |
| `instagram_direct_message_activity` | 571 | 571 | 545 |
| summary Posts published | 0 | **35** | 35 |
| summary Stories published | 0 | **15** | 15 |
| summary Comments published | 0 | **50** | 50 |
| summary Ads viewed | 40 | 40 | 40 |

## Test plan

- [x] 55 Python tests pass
- [x] Pre-commit Playwright e2e passes
- [x] Both random fixtures (`./tests/generate_random_fixtures.sh`) produce fully-populated tables

Refs scriptdev issue 9808995489.

🤖 Generated with [Claude Code](https://claude.com/claude-code)