### PR TITLE
Realign worker telemetry with feldspar's Logger pattern

### DIFF
--- a/packages/feldspar/src/framework/assembly.ts
+++ b/packages/feldspar/src/framework/assembly.ts
@@ -4,17 +4,22 @@ import ReactFactory from "./visualization/react/factory";
 import { PageFactory } from "./visualization/react/factories/base";
 import CommandRouter from './command_router'
 import WorkerProcessingEngine from "./processing/worker_engine";
+import { LogForwarder, LogLevel, WindowLogSource } from "./logging";
 
 export default class Assembly {
   processingEngine: WorkerProcessingEngine;
   visualizationEngine: ReactEngine;
   router: CommandRouter
+  logForwarder: LogForwarder
+  windowLogSource: WindowLogSource
 
-  constructor(worker: Worker, bridge: Bridge, locale: string = "de", factories: PageFactory[] = []) {
+  constructor(worker: Worker, bridge: Bridge, locale: string = "de", factories: PageFactory[] = [], logLevel: LogLevel = 'warn') {
     const sessionId = String(Date.now())
     const visualizationFactory = new ReactFactory(factories);
     this.visualizationEngine = new ReactEngine(visualizationFactory);
     this.router = new CommandRouter(bridge, this.visualizationEngine)
-    this.processingEngine = new WorkerProcessingEngine(sessionId, locale, worker, this.router);
+    this.logForwarder = new LogForwarder((entries) => bridge.sendLogs(entries), logLevel)
+    this.windowLogSource = new WindowLogSource(this.logForwarder)
+    this.processingEngine = new WorkerProcessingEngine(sessionId, locale, worker, this.router, this.logForwarder);
   }
 }

--- a/packages/feldspar/src/framework/processing/worker_engine.test.ts
+++ b/packages/feldspar/src/framework/processing/worker_engine.test.ts
@@ -1,0 +1,101 @@
+import WorkerProcessingEngine from './worker_engine'
+import { Logger, LogLevel } from '../logging'
+import { Command, Response } from '../types/commands'
+import { CommandHandler } from '../types/modules'
+
+class FakeWorker {
+  onmessage: ((event: any) => void) | null = null
+  onerror: ((error: any) => void) | null = null
+  postMessage: (...args: any[]) => void = () => {}
+  terminate = (): void => {}
+  addEventListener = (): void => {}
+  removeEventListener = (): void => {}
+  dispatchEvent = (): boolean => true
+}
+
+class FakeLogger implements Logger {
+  entries: Array<{ level: LogLevel, message: string, context?: Record<string, unknown> }> = []
+  flushCount = 0
+  log (level: LogLevel, message: string, context?: Record<string, unknown>): void {
+    this.entries.push({ level, message, context })
+  }
+  flush (): void {
+    this.flushCount++
+  }
+}
+
+class FakeHandler implements CommandHandler {
+  async onCommand (_command: Command): Promise<Response> {
+    return { __type__: 'Response', command: _command, payload: { __type__: 'PayloadVoid', value: undefined } }
+  }
+}
+
+function makeEngine (): { engine: WorkerProcessingEngine, logger: FakeLogger, worker: FakeWorker } {
+  const worker = new FakeWorker()
+  const logger = new FakeLogger()
+  const engine = new WorkerProcessingEngine('s1', 'en', worker as unknown as Worker, new FakeHandler(), logger)
+  return { engine, logger, worker }
+}
+
+describe('WorkerProcessingEngine.handleEvent', () => {
+  it('routes workerLog events through logger with the provided level', () => {
+    const { engine, logger } = makeEngine()
+    engine.handleEvent({ data: { eventType: 'workerLog', level: 'debug', message: 'starting cycle' } })
+    expect(logger.entries).toContainEqual({ level: 'debug', message: 'starting cycle', context: undefined })
+  })
+
+  it('falls back to info for unknown workerLog levels', () => {
+    const { engine, logger } = makeEngine()
+    engine.handleEvent({ data: { eventType: 'workerLog', level: 'banana', message: 'oops' } })
+    expect(logger.entries).toContainEqual({ level: 'info', message: 'oops', context: undefined })
+  })
+
+  it('accepts each valid LogLevel without falling back', () => {
+    const { engine, logger } = makeEngine()
+    const levels: LogLevel[] = ['debug', 'info', 'warn', 'error']
+    for (const level of levels) {
+      engine.handleEvent({ data: { eventType: 'workerLog', level, message: `at-${level}` } })
+    }
+    expect(logger.entries.map(e => e.level)).toEqual(levels)
+  })
+
+  it('routes worker error events as error log with stack context', () => {
+    const { engine, logger } = makeEngine()
+    engine.handleEvent({ data: { eventType: 'error', error: 'KeyError', stack: 'trace' } })
+    expect(logger.entries).toContainEqual({
+      level: 'error',
+      message: 'Python error: KeyError',
+      context: { stack: 'trace' },
+    })
+  })
+
+  it('flushes the logger after handling each event', () => {
+    const { engine, logger } = makeEngine()
+    expect(logger.flushCount).toBe(0)
+    engine.handleEvent({ data: { eventType: 'workerLog', level: 'info', message: 'one' } })
+    expect(logger.flushCount).toBe(1)
+    engine.handleEvent({ data: { eventType: 'error', error: 'boom', stack: '' } })
+    expect(logger.flushCount).toBe(2)
+  })
+
+  it('logs a warn for an unsupported event type', () => {
+    const { engine, logger } = makeEngine()
+    engine.handleEvent({ data: { eventType: 'mysteryEvent' } })
+    expect(logger.entries).toContainEqual({
+      level: 'warn',
+      message: 'Received unsupported worker event: mysteryEvent',
+      context: undefined,
+    })
+  })
+
+  it('firstRunCycle posts data with sessionId and locale', () => {
+    const worker = new FakeWorker()
+    const posted: any[] = []
+    worker.postMessage = (msg: any): void => { posted.push(msg) }
+    const engine = new WorkerProcessingEngine('s42', 'nl', worker as unknown as Worker, new FakeHandler(), new FakeLogger())
+    engine.firstRunCycle()
+    expect(posted).toEqual([
+      { eventType: 'firstRunCycle', data: { sessionId: 's42', locale: 'nl' } },
+    ])
+  })
+})

--- a/packages/feldspar/src/framework/processing/worker_engine.ts
+++ b/packages/feldspar/src/framework/processing/worker_engine.ts
@@ -1,27 +1,49 @@
 import { CommandHandler } from '../types/modules'
-import { CommandSystemEvent, CommandSystemLog, isCommand, Response } from '../types/commands'
+import { CommandSystemEvent, isCommand, Response } from '../types/commands'
+import { Logger, LogLevel } from '../logging'
 
-export default class WorkerProcessingEngine  {
+const VALID_LOG_LEVELS: LogLevel[] = ['debug', 'info', 'warn', 'error']
+
+function toLogLevel (value: unknown): LogLevel {
+  return VALID_LOG_LEVELS.includes(value as LogLevel) ? (value as LogLevel) : 'info'
+}
+
+export default class WorkerProcessingEngine {
   sessionId: String
   locale: String
   worker: Worker
   commandHandler: CommandHandler
+  logger?: Logger
 
   resolveInitialized!: () => void
   resolveContinue!: () => void
 
-  constructor (sessionId: string, locale: string, worker: Worker, commandHandler: CommandHandler) {
+  constructor (
+    sessionId: string,
+    locale: string,
+    worker: Worker,
+    commandHandler: CommandHandler,
+    logger?: Logger
+  ) {
     this.sessionId = sessionId
     this.locale = locale
     this.commandHandler = commandHandler
     this.worker = worker
-    this.worker.onerror = console.log
+    this.logger = logger
+    this.initWorkerEventHandlers()
+  }
+
+  private initWorkerEventHandlers (): void {
     this.worker.onmessage = (event) => {
-      console.log(
-        '[WorkerProcessingEngine] Received event from worker: ',
-        event.data.eventType
-      )
+      this.logger?.log('debug', `Received event from worker: ${event.data.eventType}`)
       this.handleEvent(event)
+    }
+    this.worker.onerror = (error) => {
+      this.logger?.log('error', `Worker error: ${error.message}`, {
+        filename: error.filename,
+        lineno: error.lineno,
+        colno: error.colno,
+      })
     }
   }
 
@@ -35,59 +57,33 @@ export default class WorkerProcessingEngine  {
 
   handleEvent (event: any): void {
     const { eventType } = event.data
-    console.log('[ReactEngine] received eventType: ', eventType)
     switch (eventType) {
       case 'initialiseDone':
-        console.log('[ReactEngine] received: initialiseDone')
+        this.logger?.log('debug', 'Worker initialisation done')
         this.resolveInitialized()
         break
 
       case 'runCycleDone':
-        console.log('[ReactEngine] received: event', event.data.scriptEvent)
+        this.logger?.log('debug', 'Worker run cycle done')
         this.handleRunCycle(event.data.scriptEvent)
         break
 
       case 'error':
-        console.error(
-          '[ReactEngine] worker error:',
-          event.data.error,
-          event.data.stack
-        )
-        this.handleWorkerError(event.data.error, event.data.stack)
+        this.logger?.log('error', `Python error: ${event.data.error}`, { stack: event.data.stack })
         break
 
       case 'workerLog':
-        this.forwardWorkerLog(event.data.level, event.data.message)
+        this.logger?.log(toLogLevel(event.data.level), event.data.message)
         break
 
       default:
-        console.log(
-          '[ReactEngine] received unsupported flow event: ',
-          eventType
-        )
+        this.logger?.log('warn', `Received unsupported worker event: ${eventType}`)
     }
-  }
-
-  handleWorkerError (error: string, stack: string): void {
-    const message = `[Worker] Error in runCycle: ${error}${stack ? `\n${stack}` : ''}`
-    this.forwardWorkerLog('error', message)
-  }
-
-  forwardWorkerLog (level: string, message: string): void {
-    const command: CommandSystemLog = {
-      __type__: 'CommandSystemLog',
-      level,
-      message,
-      json_string: JSON.stringify({ level, message })
-    }
-    this.commandHandler.onCommand(command).then(
-      () => {},
-      () => {}
-    )
+    this.logger?.flush()
   }
 
   start (): void {
-    console.log('[WorkerProcessingEngine] started')
+    this.logger?.log('debug', 'Worker started')
     const waitForInitialization: Promise<void> = this.waitForInitialization()
 
     waitForInitialization.then(
@@ -102,7 +98,7 @@ export default class WorkerProcessingEngine  {
   async waitForInitialization (): Promise<void> {
     return await new Promise<void>((resolve) => {
       this.resolveInitialized = resolve
-      console.debug('[WorkerProcessingEngine] waiting for initialisation')
+      this.logger?.log('debug', 'Waiting for worker initialisation')
       this.worker.postMessage({ eventType: 'initialise' })
     })
   }
@@ -118,7 +114,6 @@ export default class WorkerProcessingEngine  {
   }
 
   nextRunCycle (response: Response): void {
-    console.log('[WorkerProcessingEngine] nextRunCycle');
     this.worker.postMessage({ eventType: 'nextRunCycle', response })
   }
 


### PR DESCRIPTION
## Summary

Cambridge has had `logging.ts` (the `Logger` / `LogForwarder` / `WindowLogSource` abstraction) in tree since the `86445c4` feldspar rebase, but it was never wired up: `assembly.ts` didn't construct a `LogForwarder`, and `worker_engine.ts` (commit `3c1fe7f` "Surface worker errors and runCycle telemetry to AppSignal") routed `CommandSystemLog` directly via `commandHandler.onCommand` instead of through the `Logger`.

That created two problems:
- The bypass meant non-error logs skipped the `LogForwarder` buffer / flush / level filter. `WindowLogSource` window-error capture was dead code on this branch.
- Every downstream merge against Cambridge (Cornell, future forks) had to reconcile `worker_engine.ts` even when their copy was already aligned with feldspar.

Feldspar #785 backported the foundational pieces (workerLog event handling + FlushLogs sentinel + runCycle telemetry + split try/catch). This PR brings Cambridge in line with feldspar `develop`.

## Changes

**`assembly.ts`** — construct a `LogForwarder` bound to `bridge.sendLogs`, plus a `WindowLogSource` that auto-captures uncaught errors and unhandled promise rejections. Pass the `LogForwarder` into `WorkerProcessingEngine`. New optional `logLevel` constructor argument matches feldspar's signature.

**`worker_engine.ts`** — adopt feldspar's Logger-based event handling:
- All `console.log` / `console.error` become `this.logger?.log(...)` at the appropriate level.
- The `workerLog` event routes through the `Logger` via a `toLogLevel()` narrowing function — a malformed level from the worker degrades to `info` rather than failing typecheck.
- `forwardWorkerLog` and `handleWorkerError` are removed (the parallel `CommandSystemLog` channel that bypassed the Logger).
- `CommandSystemLog` import is no longer needed.
- Cambridge-specific extensions over feldspar are preserved: the `locale` constructor parameter and the locale-aware `firstRunCycle` payload.

**`worker_engine.test.ts`** (new) — mirrors feldspar's test for the same engine, plus one Cambridge-specific case asserting that `firstRunCycle` posts both `sessionId` and `locale`. The six core cases (workerLog routing, level fallback, valid-level acceptance, error-event routing, flush-per-event, unsupported-event warn) match feldspar.

## Test plan

- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm exec jest` — 13/13 (truncation 7 + worker_engine 7)
- [x] `poetry run pytest` — 55/55 (unchanged)
- [x] Pre-commit Playwright e2e — 1/1

🤖 Generated with [Claude Code](https://claude.com/claude-code)