### PR TITLE
Reject negative timestamps in get_timestamp

### DIFF
--- a/packages/python/port/script.py
+++ b/packages/python/port/script.py
@@ -117,6 +117,8 @@ def get_timestamp(data, *key_path):
     value = get_in(data, *key_path) if key_path else data
     if value is None:
         return None
+    if isinstance(value, (int, float)) and value < 0:
+        return None
     try:
         return parse_datetime(value)
     except (TypeError, ValueError, OSError, OverflowError):


### PR DESCRIPTION
## Summary

- Adds `if isinstance(value, (int, float)) and value < 0: return None` guard to `get_timestamp`
- Instagram exports should not contain pre-epoch timestamps; a negative value indicates malformed data and previously parsed into a valid but nonsensical 17th-century date instead of being skipped
- All 59 existing Python tests still pass

## Test plan

- [x] Python pytest: 59 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)