### PR TITLE
Sync feldspar: fix sys.modules pollution in test_script_wrapper

### DIFF
--- a/packages/python/tests/test_script_wrapper.py
+++ b/packages/python/tests/test_script_wrapper.py
@@ -2,25 +2,13 @@
 
 import logging
 import sys
-import types
 from pathlib import Path
 
 # Add packages/python to sys.path so the `port` package resolves.
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-# Stub `port.script` and `port.api.file_utils` before importing `port.main`.
-# Their real modules pull in pandas (via props.py) and Pyodide-only `js`
-# respectively, neither of which is needed for testing the wrapper.
-_fake_script = types.ModuleType("port.script")
-_fake_script.process = lambda *_: iter([])
-sys.modules["port.script"] = _fake_script
-
-_fake_file_utils = types.ModuleType("port.api.file_utils")
-_fake_file_utils.AsyncFileAdapter = lambda value: value
-sys.modules["port.api.file_utils"] = _fake_file_utils
-
-from port.main import ScriptWrapper  # noqa: E402
-from port.api.commands import CommandUIRender, FlushLogs  # noqa: E402
+from port.main import ScriptWrapper
+from port.api.commands import CommandUIRender, FlushLogs
 
 
 class _StubPage:


### PR DESCRIPTION
## Summary

- Cherry-pick of eyra/feldspar#787: removes module-level `sys.modules` stubs from `test_script_wrapper.py` that were poisoning the module cache for all test files in the same pytest session
- `file_utils.py` already has the `try/except` guard in Cambridge, so no change needed there

## Test plan

- [ ] `poetry run pytest tests/` passes (59/59)

🤖 Generated with [Claude Code](https://claude.com/claude-code)