### PR TITLE
Sync feldspar: make cancel optional in PropsUIPromptConfirm

### DIFF
--- a/packages/feldspar/src/framework/types/prompts.ts
+++ b/packages/feldspar/src/framework/types/prompts.ts
@@ -20,10 +20,10 @@ export interface PropsUIPromptConfirm {
   __type__: 'PropsUIPromptConfirm'
   text: Text
   ok: Text
-  cancel: Text
+  cancel?: Text
 }
 export function isPropsUIPromptConfirm (arg: any): arg is PropsUIPromptConfirm {
-  return isInstanceOf<PropsUIPromptConfirm>(arg, 'PropsUIPromptConfirm', ['text', 'ok', 'cancel'])
+  return isInstanceOf<PropsUIPromptConfirm>(arg, 'PropsUIPromptConfirm', ['text', 'ok'])
 }
 
 export interface PropsUIPromptFileInput {

--- a/packages/feldspar/src/framework/visualization/react/ui/prompts/confirm.tsx
+++ b/packages/feldspar/src/framework/visualization/react/ui/prompts/confirm.tsx
@@ -26,7 +26,9 @@ export const Confirm = (props: Props): JSX.Element => {
       <BodyLarge text={text} margin='mb-4' />
       <div className='flex flex-row gap-4'>
         <PrimaryButton label={ok} onClick={handleOk} color='text-grey1 bg-tertiary' />
-        <PrimaryButton label={cancel} onClick={handleCancel} color='text-white bg-primary' />
+        {cancel !== undefined && (
+          <PrimaryButton label={cancel} onClick={handleCancel} color='text-white bg-primary' />
+        )}
       </div>
     </>
   )
@@ -35,13 +37,13 @@ export const Confirm = (props: Props): JSX.Element => {
 interface Copy {
   text: string
   ok: string
-  cancel: string
+  cancel: string | undefined
 }
 
 function prepareCopy ({ text, ok, cancel, locale }: Props): Copy {
   return {
     text: Translator.translate(text, locale),
     ok: Translator.translate(ok, locale),
-    cancel: Translator.translate(cancel, locale)
+    cancel: cancel !== undefined ? Translator.translate(cancel, locale) : undefined
   }
 }

--- a/packages/python/port/api/props.py
+++ b/packages/python/port/api/props.py
@@ -75,14 +75,15 @@ class PropsUIPromptConfirm:
 
     text: Translatable
     ok: Translatable
-    cancel: Translatable
+    cancel: Optional[Translatable] = None
 
     def toDict(self):
         dict = {}
         dict["__type__"] = "PropsUIPromptConfirm"
         dict["text"] = self.text.toDict()
         dict["ok"] = self.ok.toDict()
-        dict["cancel"] = self.cancel.toDict()
+        if self.cancel is not None:
+            dict["cancel"] = self.cancel.toDict()
         return dict
 
 

--- a/packages/python/tests/test_props_confirm.py
+++ b/packages/python/tests/test_props_confirm.py
@@ -1,0 +1,29 @@
+"""Tests for PropsUIPromptConfirm serialization — cancel is optional."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from port.api.props import PropsUIPromptConfirm, Translatable
+
+
+def _t(en: str) -> Translatable:
+    return Translatable({"en": en, "nl": en})
+
+
+def test_confirm_with_cancel_serializes_cancel():
+    prompt = PropsUIPromptConfirm(text=_t("Are you sure?"), ok=_t("Yes"), cancel=_t("No"))
+    d = prompt.toDict()
+    assert d["__type__"] == "PropsUIPromptConfirm"
+    assert d["ok"]["translations"]["en"] == "Yes"
+    assert "cancel" in d
+    assert d["cancel"]["translations"]["en"] == "No"
+
+
+def test_confirm_without_cancel_omits_cancel():
+    prompt = PropsUIPromptConfirm(text=_t("Try again?"), ok=_t("Try again"))
+    d = prompt.toDict()
+    assert d["__type__"] == "PropsUIPromptConfirm"
+    assert d["ok"]["translations"]["en"] == "Try again"
+    assert "cancel" not in d


### PR DESCRIPTION
## Summary
- Cherry-picks `fix: make cancel optional in PropsUIPromptConfirm` from feldspar upstream
- `cancel` is now `Optional` in Python dataclass and `cancel?` in TypeScript interface
- React component conditionally renders the cancel button only when provided
- Adds Python unit tests for both with/without cancel cases

## Test plan
- [x] E2e test passes (verified via pre-commit hook)
- [ ] Verify confirm prompt renders correctly without a cancel button

🤖 Generated with [Claude Code](https://claude.com/claude-code)